### PR TITLE
feat(notes): wikilink parser, link/tag indexes, and REST CRUD API

### DIFF
--- a/.task-state.json
+++ b/.task-state.json
@@ -680,6 +680,70 @@
         "cargo test, cargo check, cargo clippy pass"
       ],
       "fetched_body": true
+    },
+    {
+      "number": 306,
+      "priority": "medium",
+      "title": "[FEATURE] Frontend WebSocket Sync Service",
+      "status": "completed",
+      "depends_on": [],
+      "blocks": [],
+      "acceptance_summary": [
+        "SyncService with connect/disconnect/pushChange methods created",
+        "SyncStatusComponent page showing connection status, last sync, pending changes",
+        "WebSocket connection with ping/keepalive",
+        "rxjs Observable for receiving sync changes"
+      ],
+      "fetched_body": true
+    },
+    {
+      "number": 287,
+      "priority": "medium",
+      "title": "[FEATURE] Template Engine for Daily Notes",
+      "status": "completed",
+      "depends_on": [],
+      "blocks": [],
+      "acceptance_summary": [
+        "NoteTemplate struct with name, content, variables fields",
+        "render_template() with {{variable}}, {{date:format}}, {{time:format}} support",
+        "list_templates/save_template/delete_template/get_template functions",
+        "create_daily_note() generating daily/YYYY-MM-DD notes from templates",
+        "REST endpoints: GET /templates, PUT /templates/{name}, DELETE /templates/{name}, POST /notes/daily"
+      ],
+      "fetched_body": true
+    },
+    {
+      "number": 288,
+      "priority": "medium",
+      "title": "[FEATURE] Frontmatter Validation",
+      "status": "completed",
+      "depends_on": [],
+      "blocks": [],
+      "acceptance_summary": [
+        "FrontmatterSchema struct with required_fields, field_types, allowed_tags, max_tags",
+        "FieldType enum: String, Number, Date, TagList, StringList",
+        "validate_frontmatter() returning list of validation errors",
+        "get_default_schema() with title required and date/tag types",
+        "Default schema registered on server startup",
+        "Schema persistence: save_schema/load_schema/list_schemas/delete_schema"
+      ],
+      "fetched_body": true
+    },
+    {
+      "number": 308,
+      "priority": "low",
+      "title": "[FEATURE] Frontend Testing Infrastructure",
+      "status": "completed",
+      "depends_on": [],
+      "blocks": [],
+      "acceptance_summary": [
+        "karma.conf.js configured with ChromeHeadless, jasmine, coverage",
+        "test.ts entry point for Angular testing environment",
+        "tsconfig.spec.json for test compilation",
+        "Sample specs for ApexStoreService (5 test cases)",
+        "Sample specs for ToastService (12 test cases covering all methods)"
+      ],
+      "fetched_body": true
     }
   ],
   "todos": [
@@ -1099,6 +1163,110 @@
       "files": [],
       "depends_on": ["T268_1", "T268_2"],
       "notes": "cargo test --all-features -- core::engine::transaction: 15 passed, 0 failed. cargo clippy --all-targets --all-features -- -D warnings: passes. cargo fmt --all: passes."
+    },
+    {
+      "id": "T306_1",
+      "description": "Issue #306: Create SyncService with connect/disconnect/pushChange and Observable",
+      "status": "done",
+      "files": ["frontend/src/app/services/sync.service.ts"],
+      "depends_on": [],
+      "notes": "Created SyncService with WebSocket management, ping keepalive, status/change Observables"
+    },
+    {
+      "id": "T306_2",
+      "description": "Issue #306: Create SyncStatusComponent page with status display",
+      "status": "done",
+      "files": ["frontend/src/app/pages/sync-status/sync-status.component.ts"],
+      "depends_on": ["T306_1"],
+      "notes": "Created SyncStatusComponent showing connection status, last sync time, pending changes count"
+    },
+    {
+      "id": "T306_3",
+      "description": "Issue #306: Register sync-status route in app.routes.ts",
+      "status": "done",
+      "files": ["frontend/src/app/app.routes.ts"],
+      "depends_on": ["T306_2"],
+      "notes": "Added route for /sync-status pointing to SyncStatusComponent"
+    },
+    {
+      "id": "T287_1",
+      "description": "Issue #287: Create template.rs with NoteTemplate, render_template, template CRUD, daily notes",
+      "status": "done",
+      "files": ["src/notes/template.rs"],
+      "depends_on": [],
+      "notes": "Created template module with render_template (variable/date/time substitution), list/save/get/delete template, create_daily_note"
+    },
+    {
+      "id": "T287_2",
+      "description": "Issue #287: Add pub mod template; to src/notes/mod.rs and re-exports",
+      "status": "done",
+      "files": ["src/notes/mod.rs"],
+      "depends_on": ["T287_1"],
+      "notes": "Added pub mod template; and pub use template::{render_template, NoteTemplate};"
+    },
+    {
+      "id": "T287_3",
+      "description": "Issue #287: Add REST endpoints for templates and daily notes",
+      "status": "done",
+      "files": ["src/api/notes.rs"],
+      "depends_on": ["T287_2"],
+      "notes": "Added GET /templates, PUT /templates/{name}, DELETE /templates/{name}, POST /notes/daily handlers"
+    },
+    {
+      "id": "T288_1",
+      "description": "Issue #288: Create validate.rs with FrontmatterSchema, validate_frontmatter, schema CRUD",
+      "status": "done",
+      "files": ["src/notes/validate.rs"],
+      "depends_on": [],
+      "notes": "Created validate module with FrontmatterSchema, FieldType enum, validate_frontmatter, get_default_schema, schema persistence"
+    },
+    {
+      "id": "T288_2",
+      "description": "Issue #288: Add pub mod validate; to src/notes/mod.rs",
+      "status": "done",
+      "files": ["src/notes/mod.rs"],
+      "depends_on": ["T288_1"],
+      "notes": "Added pub mod validate; and pub use validate::FrontmatterSchema;"
+    },
+    {
+      "id": "T288_3",
+      "description": "Issue #288: Register default frontmatter schema on server startup",
+      "status": "done",
+      "files": ["src/bin/server.rs"],
+      "depends_on": ["T288_2"],
+      "notes": "Added register_default_schema() call in server.rs after engine initialization"
+    },
+    {
+      "id": "T308_1",
+      "description": "Issue #308: Create karma.conf.js for Angular testing",
+      "status": "done",
+      "files": ["frontend/karma.conf.js"],
+      "depends_on": [],
+      "notes": "Created karma config with ChromeHeadless, jasmine, coverage, kjhtml reporter"
+    },
+    {
+      "id": "T308_2",
+      "description": "Issue #308: Create test.ts entry point and tsconfig.spec.json",
+      "status": "done",
+      "files": ["frontend/src/test.ts", "frontend/tsconfig.spec.json"],
+      "depends_on": ["T308_1"],
+      "notes": "Created test.ts with Angular testing environment init, tsconfig.spec.json with jasmine types"
+    },
+    {
+      "id": "T308_3",
+      "description": "Issue #308: Add test builder to angular.json",
+      "status": "done",
+      "files": ["frontend/angular.json"],
+      "depends_on": ["T308_2"],
+      "notes": "Added karma test builder configuration to angular.json"
+    },
+    {
+      "id": "T308_4",
+      "description": "Issue #308: Create sample specs for ApexStoreService and ToastService",
+      "status": "done",
+      "files": ["frontend/src/app/services/apex-store.service.spec.ts", "frontend/src/app/services/toast.service.spec.ts"],
+      "depends_on": ["T308_1"],
+      "notes": "Created 5 spec cases for ApexStoreService (put, get, delete, listKeys, getStats) and 12 spec cases for ToastService"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-ws"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d4f2fbee3ef7a22fa6cb0e416b962237a167ed0419f22d4e451da2d7f082f8"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytestring",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
 name = "actix_derive"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +463,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix-web-httpauth",
+ "actix-ws",
  "aes-gcm",
  "async-graphql",
  "async-graphql-actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 ureq = "2.12"
 sqlparser = "0.45"
 jsonschema = "0.18"
+actix-ws = "0.3"
 
 [dev-dependencies]
 tempfile = "3.24"

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -56,6 +56,15 @@
             "development": { "buildTarget": "apexstore-frontend:build:development" }
           },
           "defaultConfiguration": "development"
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "scripts": []
+          }
         }
       }
     }

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -1,0 +1,40 @@
+// Karma configuration file for ApexStore frontend
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {
+        random: true,
+        seed: null, // use constant seed for reproducible runs
+      },
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true,
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/apexstore-frontend'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' },
+      ],
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['ChromeHeadless'],
+    restartOnFileChange: true,
+    singleRun: false,
+    failOnEmptyTestSuite: false,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+  });
+};

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -33,6 +33,12 @@
         </span>
         <span>GitHub</span>
       </a>
+      <button class="nav-item theme-toggle" (click)="toggleTheme()" title="Toggle theme">
+        <span class="nav-icon">
+          <hugeicons-icon [icon]="theme() === 'dark' ? SunIcon : MoonIcon" [size]="17" [strokeWidth]="1.5" />
+        </span>
+        <span>{{ theme() === 'dark' ? 'Light Mode' : 'Dark Mode' }}</span>
+      </button>
     </div>
   </aside>
 

--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -85,6 +85,14 @@
   margin-top: 12px;
 }
 
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  font-family: var(--font-sans);
+}
+
 .main-content {
   flex: 1;
   overflow-y: auto;

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -18,6 +18,14 @@ import {
   DatabaseIcon,
   Search01Icon,
   CpuIcon,
+  Settings01Icon,
+  Upload01Icon,
+  Download01Icon,
+  Add01Icon,
+  Delete01Icon,
+  PlayIcon,
+  PauseIcon,
+  Edit01Icon,
 } from '@hugeicons/core-free-icons';
 import { ToastComponent } from './components/toast/toast.component';
 import type { IconSvgObject } from '@hugeicons/angular';
@@ -55,6 +63,8 @@ export class AppComponent {
         { path: '/keys', icon: Key01Icon, label: 'Key Explorer' },
         { path: '/features', icon: Flag01Icon, label: 'Feature Flags' },
         { path: '/sql-runner', icon: Search01Icon, label: 'SQL Runner' },
+        { path: '/vector-search', icon: Search01Icon, label: 'Vector Search' },
+        { path: '/bulk-import', icon: Upload01Icon, label: 'Bulk Import' },
       ]
     },
     {
@@ -72,6 +82,11 @@ export class AppComponent {
         { path: '/compaction', icon: HardDriveIcon, label: 'Compaction' },
         { path: '/rate-limits', icon: BarChartIcon, label: 'Rate Limits' },
         { path: '/backup', icon: DatabaseIcon, label: 'Backup' },
+        { path: '/replication', icon: Share08Icon, label: 'Replication' },
+        { path: '/cdc', icon: DatabaseIcon, label: 'CDC' },
+        { path: '/chaos', icon: CpuIcon, label: 'Chaos' },
+        { path: '/backpressure', icon: CpuIcon, label: 'Backpressure' },
+        { path: '/data-scrubber', icon: Delete01Icon, label: 'Data Scrubber' },
       ]
     },
     {
@@ -79,6 +94,8 @@ export class AppComponent {
       items: [
         { path: '/webhooks', icon: ZapIcon, label: 'Webhooks' },
         { path: '/pubsub', icon: Share08Icon, label: 'Pub/Sub' },
+        { path: '/data-sync', icon: Share08Icon, label: 'Data Sync' },
+        { path: '/wasm-plugins', icon: CpuIcon, label: 'WASM Plugins' },
       ]
     },
     {
@@ -86,6 +103,10 @@ export class AppComponent {
       items: [
         { path: '/admin', icon: LockPasswordIcon, label: 'Tokens' },
         { path: '/access-control', icon: LockPasswordIcon, label: 'Access Control' },
+        { path: '/server-config', icon: Settings01Icon, label: 'Server Config' },
+        { path: '/telemetry', icon: BarChartIcon, label: 'Telemetry' },
+        { path: '/quotas', icon: DatabaseIcon, label: 'Quotas' },
+        { path: '/cicd', icon: PlayIcon, label: 'CI/CD' },
       ]
     },
   ]);

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -26,6 +26,8 @@ import {
   PlayIcon,
   PauseIcon,
   Edit01Icon,
+  Sun01Icon,
+  Moon01Icon,
 } from '@hugeicons/core-free-icons';
 import { ToastComponent } from './components/toast/toast.component';
 import type { IconSvgObject } from '@hugeicons/angular';
@@ -46,6 +48,26 @@ export class AppComponent {
   readonly ZapIcon = ZapIcon;
   readonly GithubIcon = Github01Icon;
   readonly BookOpenIcon = BookOpenIcon;
+  readonly SunIcon = Sun01Icon;
+  readonly MoonIcon = Moon01Icon;
+
+  theme = signal<'dark' | 'light'>(
+    (localStorage.getItem('apex_theme') as 'dark' | 'light') || 'dark'
+  );
+
+  constructor() {
+    this.applyTheme();
+  }
+
+  toggleTheme(): void {
+    this.theme.update(t => (t === 'dark' ? 'light' : 'dark'));
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
+    document.documentElement.classList.toggle('light-mode', this.theme() === 'light');
+    localStorage.setItem('apex_theme', this.theme());
+  }
 
   navGroups = signal<NavGroup[]>([
     {
@@ -63,6 +85,7 @@ export class AppComponent {
         { path: '/keys', icon: Key01Icon, label: 'Key Explorer' },
         { path: '/features', icon: Flag01Icon, label: 'Feature Flags' },
         { path: '/sql-runner', icon: Search01Icon, label: 'SQL Runner' },
+        { path: '/graphql', icon: PlayIcon, label: 'GraphQL Playground' },
         { path: '/vector-search', icon: Search01Icon, label: 'Vector Search' },
         { path: '/bulk-import', icon: Upload01Icon, label: 'Bulk Import' },
       ]

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -13,6 +13,11 @@ import {
   NoteEditIcon,
   Share08Icon,
   Tag01Icon,
+  HardDriveIcon,
+  CheckmarkCircle01Icon,
+  DatabaseIcon,
+  Search01Icon,
+  CpuIcon,
 } from '@hugeicons/core-free-icons';
 import { ToastComponent } from './components/toast/toast.component';
 import type { IconSvgObject } from '@hugeicons/angular';
@@ -40,6 +45,8 @@ export class AppComponent {
       items: [
         { path: '/dashboard', icon: Home01Icon, label: 'Dashboard' },
         { path: '/stats', icon: BarChartIcon, label: 'Statistics' },
+        { path: '/health', icon: CheckmarkCircle01Icon, label: 'Health' },
+        { path: '/resilience', icon: CpuIcon, label: 'Resilience' },
       ]
     },
     {
@@ -47,6 +54,7 @@ export class AppComponent {
       items: [
         { path: '/keys', icon: Key01Icon, label: 'Key Explorer' },
         { path: '/features', icon: Flag01Icon, label: 'Feature Flags' },
+        { path: '/sql-runner', icon: Search01Icon, label: 'SQL Runner' },
       ]
     },
     {
@@ -55,12 +63,29 @@ export class AppComponent {
         { path: '/notes', icon: NoteEditIcon, label: 'Notes' },
         { path: '/graph', icon: Share08Icon, label: 'Graph View' },
         { path: '/tags', icon: Tag01Icon, label: 'Tags' },
+        { path: '/time-travel', icon: Share08Icon, label: 'Time Travel' },
+      ]
+    },
+    {
+      label: 'System',
+      items: [
+        { path: '/compaction', icon: HardDriveIcon, label: 'Compaction' },
+        { path: '/rate-limits', icon: BarChartIcon, label: 'Rate Limits' },
+        { path: '/backup', icon: DatabaseIcon, label: 'Backup' },
+      ]
+    },
+    {
+      label: 'Integrations',
+      items: [
+        { path: '/webhooks', icon: ZapIcon, label: 'Webhooks' },
+        { path: '/pubsub', icon: Share08Icon, label: 'Pub/Sub' },
       ]
     },
     {
       label: 'Admin',
       items: [
         { path: '/admin', icon: LockPasswordIcon, label: 'Tokens' },
+        { path: '/access-control', icon: LockPasswordIcon, label: 'Access Control' },
       ]
     },
   ]);

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -10,6 +10,9 @@ import {
   Github01Icon,
   ZapIcon,
   BookOpenIcon,
+  NoteEditIcon,
+  Share08Icon,
+  Tag01Icon,
 } from '@hugeicons/core-free-icons';
 import { ToastComponent } from './components/toast/toast.component';
 import type { IconSvgObject } from '@hugeicons/angular';
@@ -44,6 +47,14 @@ export class AppComponent {
       items: [
         { path: '/keys', icon: Key01Icon, label: 'Key Explorer' },
         { path: '/features', icon: Flag01Icon, label: 'Feature Flags' },
+      ]
+    },
+    {
+      label: 'Content',
+      items: [
+        { path: '/notes', icon: NoteEditIcon, label: 'Notes' },
+        { path: '/graph', icon: Share08Icon, label: 'Graph View' },
+        { path: '/tags', icon: Tag01Icon, label: 'Tags' },
       ]
     },
     {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -31,6 +31,7 @@ import { DataScrubberComponent } from './pages/data-scrubber/data-scrubber.compo
 import { BackpressureComponent } from './pages/backpressure/backpressure.component';
 import { WasmPluginsComponent } from './pages/wasm-plugins/wasm-plugins.component';
 import { CicdComponent } from './pages/cicd/cicd.component';
+import { SyncStatusComponent } from './pages/sync-status/sync-status.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -66,4 +67,5 @@ export const routes: Routes = [
   { path: 'backpressure', component: BackpressureComponent },
   { path: 'wasm-plugins', component: WasmPluginsComponent },
   { path: 'cicd', component: CicdComponent },
+  { path: 'sync-status', component: SyncStatusComponent },
 ];

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -16,6 +16,7 @@ import { WebhooksComponent } from './pages/webhooks/webhooks.component';
 import { PubsubComponent } from './pages/pubsub/pubsub.component';
 import { SqlRunnerComponent } from './pages/sql-runner/sql-runner.component';
 import { ResilienceComponent } from './pages/resilience/resilience.component';
+import { GraphQLComponent } from './pages/graphql/graphql.component';
 import { AccessControlComponent } from './pages/access-control/access-control.component';
 import { ReplicationComponent } from './pages/replication/replication.component';
 import { VectorSearchComponent } from './pages/vector-search/vector-search.component';
@@ -49,6 +50,7 @@ export const routes: Routes = [
   { path: 'webhooks', component: WebhooksComponent },
   { path: 'pubsub', component: PubsubComponent },
   { path: 'sql-runner', component: SqlRunnerComponent },
+  { path: 'graphql', component: GraphQLComponent },
   { path: 'resilience', component: ResilienceComponent },
   { path: 'access-control', component: AccessControlComponent },
   { path: 'replication', component: ReplicationComponent },

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,6 +4,9 @@ import { KeyExplorerComponent } from './pages/key-explorer/key-explorer.componen
 import { StatsComponent } from './pages/stats/stats.component';
 import { FeaturesComponent } from './pages/features/features.component';
 import { AdminComponent } from './pages/admin/admin.component';
+import { NotesComponent } from './pages/notes/notes.component';
+import { GraphComponent } from './pages/graph/graph.component';
+import { TagsComponent } from './pages/tags/tags.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -12,4 +15,7 @@ export const routes: Routes = [
   { path: 'stats', component: StatsComponent },
   { path: 'features', component: FeaturesComponent },
   { path: 'admin', component: AdminComponent },
+  { path: 'notes', component: NotesComponent },
+  { path: 'graph', component: GraphComponent },
+  { path: 'tags', component: TagsComponent },
 ];

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -17,6 +17,19 @@ import { PubsubComponent } from './pages/pubsub/pubsub.component';
 import { SqlRunnerComponent } from './pages/sql-runner/sql-runner.component';
 import { ResilienceComponent } from './pages/resilience/resilience.component';
 import { AccessControlComponent } from './pages/access-control/access-control.component';
+import { ReplicationComponent } from './pages/replication/replication.component';
+import { VectorSearchComponent } from './pages/vector-search/vector-search.component';
+import { DataSyncComponent } from './pages/data-sync/data-sync.component';
+import { CdcComponent } from './pages/cdc/cdc.component';
+import { BulkImportComponent } from './pages/bulk-import/bulk-import.component';
+import { ServerConfigComponent } from './pages/server-config/server-config.component';
+import { ChaosComponent } from './pages/chaos/chaos.component';
+import { TelemetryComponent } from './pages/telemetry/telemetry.component';
+import { QuotasComponent } from './pages/quotas/quotas.component';
+import { DataScrubberComponent } from './pages/data-scrubber/data-scrubber.component';
+import { BackpressureComponent } from './pages/backpressure/backpressure.component';
+import { WasmPluginsComponent } from './pages/wasm-plugins/wasm-plugins.component';
+import { CicdComponent } from './pages/cicd/cicd.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -38,4 +51,17 @@ export const routes: Routes = [
   { path: 'sql-runner', component: SqlRunnerComponent },
   { path: 'resilience', component: ResilienceComponent },
   { path: 'access-control', component: AccessControlComponent },
+  { path: 'replication', component: ReplicationComponent },
+  { path: 'vector-search', component: VectorSearchComponent },
+  { path: 'data-sync', component: DataSyncComponent },
+  { path: 'cdc', component: CdcComponent },
+  { path: 'bulk-import', component: BulkImportComponent },
+  { path: 'server-config', component: ServerConfigComponent },
+  { path: 'chaos', component: ChaosComponent },
+  { path: 'telemetry', component: TelemetryComponent },
+  { path: 'quotas', component: QuotasComponent },
+  { path: 'data-scrubber', component: DataScrubberComponent },
+  { path: 'backpressure', component: BackpressureComponent },
+  { path: 'wasm-plugins', component: WasmPluginsComponent },
+  { path: 'cicd', component: CicdComponent },
 ];

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,6 +7,16 @@ import { AdminComponent } from './pages/admin/admin.component';
 import { NotesComponent } from './pages/notes/notes.component';
 import { GraphComponent } from './pages/graph/graph.component';
 import { TagsComponent } from './pages/tags/tags.component';
+import { CompactionComponent } from './pages/compaction/compaction.component';
+import { HealthComponent } from './pages/health/health.component';
+import { RateLimitsComponent } from './pages/rate-limits/rate-limits.component';
+import { BackupComponent } from './pages/backup/backup.component';
+import { TimeTravelComponent } from './pages/time-travel/time-travel.component';
+import { WebhooksComponent } from './pages/webhooks/webhooks.component';
+import { PubsubComponent } from './pages/pubsub/pubsub.component';
+import { SqlRunnerComponent } from './pages/sql-runner/sql-runner.component';
+import { ResilienceComponent } from './pages/resilience/resilience.component';
+import { AccessControlComponent } from './pages/access-control/access-control.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -18,4 +28,14 @@ export const routes: Routes = [
   { path: 'notes', component: NotesComponent },
   { path: 'graph', component: GraphComponent },
   { path: 'tags', component: TagsComponent },
+  { path: 'compaction', component: CompactionComponent },
+  { path: 'health', component: HealthComponent },
+  { path: 'rate-limits', component: RateLimitsComponent },
+  { path: 'backup', component: BackupComponent },
+  { path: 'time-travel', component: TimeTravelComponent },
+  { path: 'webhooks', component: WebhooksComponent },
+  { path: 'pubsub', component: PubsubComponent },
+  { path: 'sql-runner', component: SqlRunnerComponent },
+  { path: 'resilience', component: ResilienceComponent },
+  { path: 'access-control', component: AccessControlComponent },
 ];

--- a/frontend/src/app/pages/access-control/access-control.component.html
+++ b/frontend/src/app/pages/access-control/access-control.component.html
@@ -1,0 +1,119 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Access Control</h1>
+      <p class="page-subtitle">Policy management for authorization</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadPolicies()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Create policy -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="LockPasswordIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Create Policy</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group">
+          <label>Name</label>
+          <input [(ngModel)]="newName" placeholder="read-only-users" />
+        </div>
+        <div class="input-group">
+          <label>Resource Pattern</label>
+          <input [(ngModel)]="newResource" placeholder="keys:*" />
+        </div>
+        <div class="input-group">
+          <label>Priority</label>
+          <input type="number" [(ngModel)]="newPriority" />
+        </div>
+        <div class="input-group">
+          <label>Effect</label>
+          <div class="effect-toggle">
+            <button class="btn btn-sm" [class.btn-success]="newEffect === 'allow'" [class.btn-secondary]="newEffect !== 'allow'" (click)="setEffect('allow')">Allow</button>
+            <button class="btn btn-sm" [class.btn-danger]="newEffect === 'deny'" [class.btn-secondary]="newEffect !== 'deny'" (click)="setEffect('deny')">Deny</button>
+          </div>
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Actions</label>
+          <div class="action-chips">
+            @for (action of actionOptions; track action) {
+              <label class="action-chip" [class.selected]="isActionSelected(action)">
+                <input type="checkbox" [checked]="isActionSelected(action)" (change)="toggleAction(action)" />
+                {{ action }}
+              </label>
+            }
+          </div>
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newName.trim() || !newResource.trim() || creating()" (click)="createPolicy()">
+        @if (creating()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Create Policy
+      </button>
+    </div>
+  </div>
+
+  <!-- Policies list -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">Policies</span>
+        <span class="badge badge-info">{{ policies().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && policies().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (policies().length === 0) {
+      <div class="empty-state">No policies configured. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="policies-table">
+          <thead>
+            <tr><th>Name</th><th>Resource</th><th>Actions</th><th>Effect</th><th>Priority</th><th>Created</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (p of policies(); track p.id) {
+              <tr [class.allow-row]="p.effect === 'allow'" [class.deny-row]="p.effect === 'deny'">
+                <td class="name-cell">{{ p.name }}</td>
+                <td class="mono resource-cell">{{ p.resource }}</td>
+                <td>
+                  <div class="action-badges">
+                    @for (a of p.actions; track a) {
+                      <span class="badge badge-info">{{ a }}</span>
+                    }
+                  </div>
+                </td>
+                <td>
+                  @if (p.effect === 'allow') {
+                    <span class="badge badge-success">Allow</span>
+                  } @else {
+                    <span class="badge badge-danger">Deny</span>
+                  }
+                </td>
+                <td>{{ p.priority }}</td>
+                <td class="time-cell">{{ nsToDate(p.created_at) | date:'dd/MM/yy HH:mm' }}</td>
+                <td>
+                  <button class="btn btn-danger btn-sm" (click)="deletePolicy(p.id, p.name)">
+                    <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/access-control/access-control.component.scss
+++ b/frontend/src/app/pages/access-control/access-control.component.scss
@@ -1,0 +1,165 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.effect-toggle {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.action-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.action-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+
+  input { display: none; }
+
+  &.selected {
+    border-color: var(--accent);
+    background: var(--accent-dim);
+    color: var(--accent);
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.policies-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  tr.allow-row td {
+    border-left: 3px solid transparent;
+  }
+
+  tr.deny-row td {
+    border-left: 3px solid var(--red-dim);
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.resource-cell {
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-badges {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}

--- a/frontend/src/app/pages/access-control/access-control.component.ts
+++ b/frontend/src/app/pages/access-control/access-control.component.ts
@@ -1,0 +1,123 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  LockPasswordIcon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  LockIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface Policy {
+  id: string;
+  name: string;
+  resource: string;
+  actions: string[];
+  effect: 'allow' | 'deny';
+  priority: number;
+  created_at: number;
+}
+
+@Component({
+  selector: 'app-access-control',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './access-control.component.html',
+  styleUrl: './access-control.component.scss'
+})
+export class AccessControlComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly LockPasswordIcon = LockPasswordIcon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly LockIcon = LockIcon;
+
+  policies = signal<Policy[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+
+  newName = '';
+  newResource = '';
+  newActions = 'Read';
+  newEffect: 'allow' | 'deny' = 'allow';
+  newPriority = 100;
+
+  actionOptions = ['Read', 'Write', 'Delete', 'Admin'];
+
+  ngOnInit(): void { this.loadPolicies(); }
+
+  loadPolicies(): void {
+    this.loading.set(true);
+    this.store.listPolicies().subscribe({
+      next: (data) => {
+        this.policies.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load policies');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createPolicy(): void {
+    if (!this.newName.trim() || !this.newResource.trim()) return;
+    this.creating.set(true);
+    this.store.createPolicy(this.newName.trim(), this.newResource.trim(), this.newActions.split(',').map(a => a.trim()), this.newEffect, this.newPriority).subscribe({
+      next: () => {
+        this.toast.success('Policy created!');
+        this.newName = '';
+        this.newResource = '';
+        this.creating.set(false);
+        this.loadPolicies();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create policy');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  deletePolicy(id: string, name: string): void {
+    if (!confirm(`Delete policy "${name}"?`)) return;
+    this.store.deletePolicy(id).subscribe({
+      next: () => {
+        this.toast.success(`Policy "${name}" deleted`);
+        this.policies.update(list => list.filter(p => p.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete policy')
+    });
+  }
+
+  toggleAction(action: string): void {
+    const actions = this.newActions.split(',').map(a => a.trim()).filter(Boolean);
+    if (actions.includes(action)) {
+      this.newActions = actions.filter(a => a !== action).join(',');
+    } else {
+      this.newActions = [...actions, action].join(',');
+    }
+  }
+
+  isActionSelected(action: string): boolean {
+    return this.newActions.split(',').map(a => a.trim()).includes(action);
+  }
+
+  setEffect(effect: 'allow' | 'deny'): void {
+    this.newEffect = effect;
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/backpressure/backpressure.component.html
+++ b/frontend/src/app/pages/backpressure/backpressure.component.html
@@ -1,0 +1,98 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Backpressure & Retry</h1>
+      <p class="page-subtitle">Backpressure and retry configuration</p>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center">
+      <button class="btn btn-secondary" (click)="loadConfig()" [disabled]="loading()">
+        @if (loading()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+        }
+        Refresh
+      </button>
+      <button class="btn btn-primary" [disabled]="saving()" (click)="saveConfig()">
+        @if (saving()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="CheckmarkCircle01Icon" [size]="16" [strokeWidth]="1.5" />
+        }
+        Save
+      </button>
+    </div>
+  </div>
+
+  <!-- Backpressure Settings -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Settings01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Backpressure</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group">
+          <label>Enabled</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="config().enabled" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="input-group">
+          <label>Max Queue Size</label>
+          <input type="number" [(ngModel)]="config().max_queue_size" min="100" max="1000000" />
+        </div>
+        <div class="input-group">
+          <label>Max Concurrency</label>
+          <input type="number" [(ngModel)]="config().max_concurrency" min="1" max="10000" />
+        </div>
+        <div class="input-group">
+          <label>Initial Backoff (ms)</label>
+          <input type="number" [(ngModel)]="config().backoff_initial_ms" min="10" max="10000" />
+        </div>
+        <div class="input-group">
+          <label>Max Backoff (ms)</label>
+          <input type="number" [(ngModel)]="config().backoff_max_ms" min="100" max="300000" />
+        </div>
+        <div class="input-group">
+          <label>Backoff Factor</label>
+          <input type="number" [(ngModel)]="config().backoff_factor" min="1" max="10" step="0.5" />
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Retry Settings -->
+  <div class="card">
+    <div class="card-header">
+      <hugeicons-icon [icon]="CpuIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Retry Configuration</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group">
+          <label>Max Retry Attempts</label>
+          <input type="number" [(ngModel)]="config().retry_max_attempts" min="0" max="20" />
+        </div>
+        <div class="input-group">
+          <label>Retry on Timeout</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="config().retry_on_timeout" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="input-group">
+          <label>Retry on Error</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="config().retry_on_error" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+      <div style="margin-top:16px;padding:12px;background:var(--bg-secondary);border-radius:8px;font-size:0.85rem;color:var(--text-secondary)">
+        Current effective config: max {{ config().retry_max_attempts }} retries with {{ config().backoff_initial_ms }}ms initial backoff (factor {{ config().backoff_factor }}), max {{ config().backoff_max_ms }}ms.
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/pages/backpressure/backpressure.component.scss
+++ b/frontend/src/app/pages/backpressure/backpressure.component.scss
@@ -1,0 +1,91 @@
+.page {
+  padding: 32px;
+  max-width: 900px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+
+  input { display: none; }
+
+  .toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: var(--border);
+    border-radius: 24px;
+    transition: 0.2s;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: white;
+      border-radius: 50%;
+      transition: 0.2s;
+    }
+  }
+
+  input:checked + .toggle-slider {
+    background: var(--accent);
+
+    &::before { transform: translateX(20px); }
+  }
+}

--- a/frontend/src/app/pages/backpressure/backpressure.component.ts
+++ b/frontend/src/app/pages/backpressure/backpressure.component.ts
@@ -1,0 +1,87 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Settings01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface BackpressureConfig {
+  enabled: boolean;
+  max_queue_size: number;
+  max_concurrency: number;
+  backoff_initial_ms: number;
+  backoff_max_ms: number;
+  backoff_factor: number;
+  retry_max_attempts: number;
+  retry_on_timeout: boolean;
+  retry_on_error: boolean;
+}
+
+@Component({
+  selector: 'app-backpressure',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './backpressure.component.html',
+  styleUrl: './backpressure.component.scss'
+})
+export class BackpressureComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Settings01Icon = Settings01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+
+  config = signal<BackpressureConfig>({
+    enabled: true,
+    max_queue_size: 10000,
+    max_concurrency: 100,
+    backoff_initial_ms: 100,
+    backoff_max_ms: 30000,
+    backoff_factor: 2,
+    retry_max_attempts: 3,
+    retry_on_timeout: true,
+    retry_on_error: false,
+  });
+  loading = signal(false);
+  saving = signal(false);
+
+  ngOnInit(): void { this.loadConfig(); }
+
+  loadConfig(): void {
+    this.loading.set(true);
+    this.store.getBackpressureConfig().subscribe({
+      next: (data) => {
+        this.config.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load backpressure configuration');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  saveConfig(): void {
+    this.saving.set(true);
+    this.store.updateBackpressureConfig(this.config()).subscribe({
+      next: () => {
+        this.toast.success('Backpressure configuration saved');
+        this.saving.set(false);
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to save configuration');
+        this.saving.set(false);
+      }
+    });
+  }
+}

--- a/frontend/src/app/pages/backup/backup.component.html
+++ b/frontend/src/app/pages/backup/backup.component.html
@@ -1,0 +1,92 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Backup</h1>
+      <p class="page-subtitle">Backup management - create, restore, and delete backups</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadBackups()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Create backup -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="HardDriveIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Create Backup</span>
+    </div>
+    <div class="card-body">
+      <div class="form-row">
+        <div class="input-group" style="flex:1">
+          <label>Backup name (optional)</label>
+          <input [(ngModel)]="backupName" placeholder="Leave empty for auto-name" (keydown.enter)="createBackup()" />
+        </div>
+        <button class="btn btn-primary" style="align-self:flex-end" [disabled]="creating()" (click)="createBackup()">
+          @if (creating()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+          }
+          {{ creating() ? 'Creating...' : 'Create Backup' }}
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Backups list -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">Backups</span>
+        <span class="badge badge-info">{{ backups().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && backups().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (backups().length === 0) {
+      <div class="empty-state">No backups yet. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="backups-table">
+          <thead>
+            <tr><th>Name</th><th>Size</th><th>Created</th><th>Status</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (b of backups(); track b.id) {
+              <tr>
+                <td class="name-cell">{{ b.name }}</td>
+                <td class="mono">{{ formatSize(b.size_kb) }}</td>
+                <td class="time-cell">{{ nsToDate(b.created_at) | date:'dd/MM/yy HH:mm' }}</td>
+                <td>
+                  @if (b.status === 'completed') {
+                    <span class="badge badge-success">Completed</span>
+                  } @else if (b.status === 'running') {
+                    <span class="badge badge-warning">Running</span>
+                  } @else {
+                    <span class="badge badge-danger">Failed</span>
+                  }
+                </td>
+                <td>
+                  <div class="action-btns">
+                    <button class="btn btn-success btn-sm" (click)="restoreBackup(b.id, b.name)" [disabled]="b.status !== 'completed'">
+                      <hugeicons-icon [icon]="ArrowRight01Icon" [size]="14" [strokeWidth]="1.5" /> Restore
+                    </button>
+                    <button class="btn btn-danger btn-sm" (click)="deleteBackup(b.id, b.name)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/backup/backup.component.scss
+++ b/frontend/src/app/pages/backup/backup.component.scss
@@ -1,0 +1,118 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.backups-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}

--- a/frontend/src/app/pages/backup/backup.component.ts
+++ b/frontend/src/app/pages/backup/backup.component.ts
@@ -1,0 +1,113 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  HardDriveIcon,
+  Add01Icon,
+  Delete01Icon,
+  ArrowRight01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface Backup {
+  id: string;
+  name: string;
+  size_kb: number;
+  created_at: number;
+  status: 'completed' | 'running' | 'failed';
+}
+
+@Component({
+  selector: 'app-backup',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './backup.component.html',
+  styleUrl: './backup.component.scss'
+})
+export class BackupComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly HardDriveIcon = HardDriveIcon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly ArrowRight01Icon = ArrowRight01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+
+  backups = signal<Backup[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+  backupName = '';
+
+  ngOnInit(): void { this.loadBackups(); }
+
+  loadBackups(): void {
+    this.loading.set(true);
+    this.store.listBackups().subscribe({
+      next: (data) => {
+        this.backups.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load backups');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createBackup(): void {
+    const name = this.backupName.trim() || `backup-${Date.now()}`;
+    this.creating.set(true);
+    this.store.createBackup(name).subscribe({
+      next: () => {
+        this.toast.success(`Backup "${name}" created successfully!`);
+        this.backupName = '';
+        this.creating.set(false);
+        this.loadBackups();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Backup creation failed');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  restoreBackup(id: string, name: string): void {
+    if (!confirm(`Restore backup "${name}"? This will overwrite current data.`)) return;
+    this.store.restoreBackup(id).subscribe({
+      next: () => {
+        this.toast.success(`Backup "${name}" restored!`);
+        this.loadBackups();
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Restore failed')
+    });
+  }
+
+  deleteBackup(id: string, name: string): void {
+    if (!confirm(`Delete backup "${name}"?`)) return;
+    this.store.deleteBackup(id).subscribe({
+      next: () => {
+        this.toast.success(`Backup "${name}" deleted`);
+        this.backups.update(list => list.filter(b => b.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Delete failed')
+    });
+  }
+
+  formatSize(kb: number): string {
+    if (kb > 1_048_576) return (kb / 1_048_576).toFixed(2) + ' GB';
+    if (kb > 1_024) return (kb / 1_024).toFixed(2) + ' MB';
+    return kb.toFixed(0) + ' KB';
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/bulk-import/bulk-import.component.html
+++ b/frontend/src/app/pages/bulk-import/bulk-import.component.html
@@ -1,0 +1,111 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Bulk Import / Export</h1>
+      <p class="page-subtitle">Import and export data in bulk</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadJobs()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <div class="grid-2col" style="margin-bottom:24px">
+    <!-- Import -->
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Upload01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Import Data</span>
+      </div>
+      <div class="card-body">
+        <div class="form-grid">
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Format</label>
+            <select [(ngModel)]="newFormat">
+              @for (f of formats; track f.value) {
+                <option [value]="f.value">{{ f.label }}</option>
+              }
+            </select>
+          </div>
+          <div class="input-group" style="grid-column:1/-1">
+            <label>File</label>
+            <input type="file" (change)="onFileSelected($event)" [disabled]="importing()" accept=".json,.csv,.ndjson" />
+          </div>
+        </div>
+        @if (importing()) {
+          <div style="display:flex;align-items:center;gap:10px;margin-top:10px">
+            <span class="spinner" style="width:18px;height:18px;border-width:2px"></span>
+            <span>Importing...</span>
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Export -->
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Download01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Export Data</span>
+      </div>
+      <div class="card-body" style="display:flex;flex-direction:column;gap:10px">
+        <p style="color:var(--text-secondary);font-size:0.85rem">Download all data as a JSON export file.</p>
+        <button class="btn btn-success" style="align-self:flex-start" (click)="downloadExport()">
+          <hugeicons-icon [icon]="Download01Icon" [size]="15" [strokeWidth]="1.5" />
+          Download Export
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Import Jobs -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="FileEditIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Import Jobs</span>
+        <span class="badge badge-info">{{ jobs().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && jobs().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (jobs().length === 0) {
+      <div class="empty-state">No import jobs yet.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="import-table">
+          <thead>
+            <tr><th>Filename</th><th>Format</th><th>Status</th><th>Progress</th><th>Errors</th><th>Created</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (j of jobs(); track j.id) {
+              <tr>
+                <td class="mono name-cell">{{ j.filename }}</td>
+                <td><span class="badge badge-info">{{ j.format }}</span></td>
+                <td><span class="badge" [ngClass]="statusClass(j.status)">{{ j.status }}</span></td>
+                <td class="mono">{{ j.records_imported }}/{{ j.records_total }}</td>
+                <td class="mono">
+                  @if (j.errors > 0) {
+                    <span style="color:var(--red)">{{ j.errors }}</span>
+                  } @else {
+                    0
+                  }
+                </td>
+                <td class="time-cell">{{ nsToDate(j.created_at) | date:'dd/MM HH:mm' }}</td>
+                <td>
+                  <button class="btn btn-danger btn-sm" (click)="deleteJob(j.id)">
+                    <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/bulk-import/bulk-import.component.scss
+++ b/frontend/src/app/pages/bulk-import/bulk-import.component.scss
@@ -1,0 +1,118 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.import-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}

--- a/frontend/src/app/pages/bulk-import/bulk-import.component.ts
+++ b/frontend/src/app/pages/bulk-import/bulk-import.component.ts
@@ -1,0 +1,132 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Upload01Icon,
+  Download01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  FileEditIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface ImportJob {
+  id: string;
+  filename: string;
+  format: 'json' | 'csv' | 'ndjson';
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  records_total: number;
+  records_imported: number;
+  errors: number;
+  created_at: number;
+  finished_at?: number;
+}
+
+@Component({
+  selector: 'app-bulk-import',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './bulk-import.component.html',
+  styleUrl: './bulk-import.component.scss'
+})
+export class BulkImportComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Upload01Icon = Upload01Icon;
+  readonly Download01Icon = Download01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly FileEditIcon = FileEditIcon;
+
+  jobs = signal<ImportJob[]>([]);
+  loading = signal(false);
+  importing = signal(false);
+
+  newFormat: 'json' | 'csv' | 'ndjson' = 'json';
+  formats: Array<{ value: string; label: string }> = [
+    { value: 'json', label: 'JSON' },
+    { value: 'csv', label: 'CSV' },
+    { value: 'ndjson', label: 'NDJSON' },
+  ];
+
+  ngOnInit(): void { this.loadJobs(); }
+
+  loadJobs(): void {
+    this.loading.set(true);
+    this.store.listImportJobs().subscribe({
+      next: (data) => {
+        this.jobs.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load import jobs');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files?.length) return;
+    const file = input.files[0];
+    this.importing.set(true);
+    this.store.createImportJob(file.name, this.newFormat).subscribe({
+      next: () => {
+        this.toast.success(`Import job created for "${file.name}"`);
+        this.importing.set(false);
+        this.loadJobs();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Import failed');
+        this.importing.set(false);
+      }
+    });
+    input.value = '';
+  }
+
+  deleteJob(id: string): void {
+    if (!confirm('Delete this import job?')) return;
+    this.store.deleteImportJob(id).subscribe({
+      next: () => {
+        this.toast.success('Import job deleted');
+        this.jobs.update(list => list.filter(j => j.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete import job')
+    });
+  }
+
+  downloadExport(): void {
+    this.store.exportData('json').subscribe({
+      next: (blob) => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `apexstore-export-${Date.now()}.json`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+        this.toast.success('Export downloaded');
+      },
+      error: () => this.toast.error('Export failed')
+    });
+  }
+
+  statusClass(status: string): string {
+    switch (status) {
+      case 'completed': return 'badge-success';
+      case 'running': return 'badge-warning';
+      case 'failed': return 'badge-danger';
+      default: return 'badge-info';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/cdc/cdc.component.html
+++ b/frontend/src/app/pages/cdc/cdc.component.html
@@ -1,0 +1,140 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">CDC</h1>
+      <p class="page-subtitle">Change Data Capture configuration</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadCDC()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- CDC Config -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="DatabaseIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">CDC Configuration</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group">
+          <label>Enabled</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="config().enabled" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="input-group">
+          <label>Retention (hours)</label>
+          <input type="number" [(ngModel)]="config().retention_hours" min="1" max="8760" />
+        </div>
+        <div class="input-group">
+          <label>Batch Size</label>
+          <input type="number" [(ngModel)]="config().batch_size" min="100" max="100000" />
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="saving()" (click)="saveConfig()">
+        @if (saving()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="CheckmarkCircle01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Save Configuration
+      </button>
+    </div>
+  </div>
+
+  <!-- Add Table -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Add01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Add Table</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Table Name</label>
+          <input [(ngModel)]="newTable" placeholder="my_table" />
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Events</label>
+          <div class="event-chips">
+            @for (evt of allEvents; track evt) {
+              <label class="event-chip" [class.selected]="isEventSelected(evt)">
+                <input type="checkbox" [checked]="isEventSelected(evt)" (change)="toggleEvent(evt)" />
+                {{ evt }}
+              </label>
+            }
+          </div>
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newTable.trim()" (click)="addTable()">
+        <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+        Add Table
+      </button>
+    </div>
+  </div>
+
+  <!-- CDC Tables List -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">Tracked Tables</span>
+        <span class="badge badge-info">{{ tables().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && tables().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (tables().length === 0) {
+      <div class="empty-state">No tables tracked. Add one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="cdc-table">
+          <thead>
+            <tr><th>Table</th><th>Events</th><th>Status</th><th>Since LSN</th><th>Last Event</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (t of tables(); track t.table) {
+              <tr>
+                <td class="mono name-cell">{{ t.table }}</td>
+                <td>
+                  <div class="event-badges">
+                    @for (evt of t.events; track evt) {
+                      <span class="badge badge-info">{{ evt }}</span>
+                    }
+                  </div>
+                </td>
+                <td>
+                  @if (t.status === 'active') {
+                    <span class="badge badge-success">Active</span>
+                  } @else {
+                    <span class="badge badge-warning">Paused</span>
+                  }
+                </td>
+                <td class="mono">{{ t.since_lsn }}</td>
+                <td class="time-cell">
+                  @if (t.last_event_at) {
+                    {{ nsToDate(t.last_event_at) | date:'dd/MM HH:mm' }}
+                  } @else {
+                    <span style="color:var(--text-muted)">—</span>
+                  }
+                </td>
+                <td>
+                  <button class="btn btn-danger btn-sm" (click)="removeTable(t.table)">
+                    <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Remove
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/cdc/cdc.component.scss
+++ b/frontend/src/app/pages/cdc/cdc.component.scss
@@ -1,0 +1,182 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+
+  input { display: none; }
+
+  .toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: var(--border);
+    border-radius: 24px;
+    transition: 0.2s;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: white;
+      border-radius: 50%;
+      transition: 0.2s;
+    }
+  }
+
+  input:checked + .toggle-slider {
+    background: var(--accent);
+
+    &::before { transform: translateX(20px); }
+  }
+}
+
+.event-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.event-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+
+  input { display: none; }
+
+  &.selected {
+    border-color: var(--accent);
+    background: var(--accent-dim);
+    color: var(--accent);
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.cdc-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.event-badges {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}

--- a/frontend/src/app/pages/cdc/cdc.component.ts
+++ b/frontend/src/app/pages/cdc/cdc.component.ts
@@ -1,0 +1,132 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  DatabaseIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface CDCTable {
+  table: string;
+  events: string[];
+  status: 'active' | 'paused';
+  since_lsn: string;
+  last_event_at?: number;
+}
+
+interface CDCConfig {
+  enabled: boolean;
+  retention_hours: number;
+  batch_size: number;
+}
+
+@Component({
+  selector: 'app-cdc',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './cdc.component.html',
+  styleUrl: './cdc.component.scss'
+})
+export class CdcComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+
+  config = signal<CDCConfig>({ enabled: false, retention_hours: 24, batch_size: 1000 });
+  tables = signal<CDCTable[]>([]);
+  loading = signal(false);
+  saving = signal(false);
+
+  newTable = '';
+  newTableEvents = 'insert,update,delete';
+
+  allEvents = ['insert', 'update', 'delete', 'truncate'];
+
+  ngOnInit(): void { this.loadCDC(); }
+
+  loadCDC(): void {
+    this.loading.set(true);
+    this.store.getCDCConfig().subscribe({
+      next: (data) => {
+        this.config.set(data.config);
+        this.tables.set(data.tables);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load CDC configuration');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  saveConfig(): void {
+    this.saving.set(true);
+    this.store.updateCDCConfig(this.config()).subscribe({
+      next: () => {
+        this.toast.success('CDC configuration updated');
+        this.saving.set(false);
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to save configuration');
+        this.saving.set(false);
+      }
+    });
+  }
+
+  addTable(): void {
+    const table = this.newTable.trim();
+    if (!table) return;
+    const events = this.newTableEvents.split(',').map(e => e.trim()).filter(Boolean);
+    this.store.addCDCTable(table, events).subscribe({
+      next: () => {
+        this.toast.success(`Table "${table}" added to CDC`);
+        this.newTable = '';
+        this.loadCDC();
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to add table')
+    });
+  }
+
+  removeTable(table: string): void {
+    if (!confirm(`Remove "${table}" from CDC tracking?`)) return;
+    this.store.removeCDCTable(table).subscribe({
+      next: () => {
+        this.toast.success(`Table "${table}" removed`);
+        this.tables.update(list => list.filter(t => t.table !== table));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to remove table')
+    });
+  }
+
+  toggleEvent(event: string): void {
+    const events = this.newTableEvents.split(',').map(e => e.trim()).filter(Boolean);
+    if (events.includes(event)) {
+      this.newTableEvents = events.filter(e => e !== event).join(',');
+    } else {
+      this.newTableEvents = [...events, event].join(',');
+    }
+  }
+
+  isEventSelected(event: string): boolean {
+    return this.newTableEvents.split(',').map(e => e.trim()).includes(event);
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/chaos/chaos.component.html
+++ b/frontend/src/app/pages/chaos/chaos.component.html
@@ -1,0 +1,108 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Chaos Engineering</h1>
+      <p class="page-subtitle">Fault injection and resilience testing</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadExperiments()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Create Experiment -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Add01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Create Experiment</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Experiment Name</label>
+          <input [(ngModel)]="newExp.name" placeholder="my-chaos-test" />
+        </div>
+        <div class="input-group">
+          <label>Type</label>
+          <select [(ngModel)]="newExp.type">
+            @for (t of expTypes; track t.value) {
+              <option [value]="t.value">{{ t.label }}</option>
+            }
+          </select>
+        </div>
+        <div class="input-group">
+          <label>Target</label>
+          <input [(ngModel)]="newExp.target" placeholder="service:port" />
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Config (JSON)</label>
+          <textarea [(ngModel)]="newExp.config" rows="3" placeholder='{"delay_ms": 200, "rate": 0.1}'></textarea>
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newExp.name.trim() || !newExp.target.trim() || creating()" (click)="createExperiment()">
+        @if (creating()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Create Experiment
+      </button>
+    </div>
+  </div>
+
+  <!-- Experiments List -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="CpuIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Experiments</span>
+        <span class="badge badge-info">{{ experiments().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && experiments().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (experiments().length === 0) {
+      <div class="empty-state">No chaos experiments. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="chaos-table">
+          <thead>
+            <tr><th>Name</th><th>Type</th><th>Target</th><th>Status</th><th>Created</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (e of experiments(); track e.id) {
+              <tr>
+                <td class="name-cell">{{ e.name }}</td>
+                <td><span class="badge" [ngClass]="typeClass(e.type)">{{ e.type }}</span></td>
+                <td class="mono">{{ e.target }}</td>
+                <td><span class="badge" [ngClass]="statusClass(e.status)">{{ e.status }}</span></td>
+                <td class="time-cell">{{ nsToDate(e.created_at) | date:'dd/MM HH:mm' }}</td>
+                <td>
+                  <div class="action-btns">
+                    <button class="btn btn-sm" [class.btn-success]="e.status === 'stopped'" [class.btn-warning]="e.status === 'running'" (click)="toggleExperiment(e.id)" [disabled]="toggling() === e.id">
+                      @if (toggling() === e.id) {
+                        <span class="spinner" style="width:14px;height:14px;border-width:2px"></span>
+                      } @else if (e.status === 'running') {
+                        <hugeicons-icon [icon]="PauseIcon" [size]="14" [strokeWidth]="1.5" /> Pause
+                      } @else {
+                        <hugeicons-icon [icon]="PlayIcon" [size]="14" [strokeWidth]="1.5" /> Start
+                      }
+                    </button>
+                    <button class="btn btn-danger btn-sm" (click)="deleteExperiment(e.id)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/chaos/chaos.component.scss
+++ b/frontend/src/app/pages/chaos/chaos.component.scss
@@ -1,0 +1,129 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+
+  textarea {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    resize: vertical;
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.chaos-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}

--- a/frontend/src/app/pages/chaos/chaos.component.ts
+++ b/frontend/src/app/pages/chaos/chaos.component.ts
@@ -1,0 +1,152 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Add01Icon,
+  Delete01Icon,
+  PlayIcon,
+  PauseIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface ChaosExperiment {
+  id: string;
+  name: string;
+  type: 'latency' | 'error' | 'crash' | 'partition' | 'resource';
+  target: string;
+  status: 'running' | 'stopped' | 'completed' | 'failed';
+  config: Record<string, unknown>;
+  created_at: number;
+}
+
+@Component({
+  selector: 'app-chaos',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './chaos.component.html',
+  styleUrl: './chaos.component.scss'
+})
+export class ChaosComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly PlayIcon = PlayIcon;
+  readonly PauseIcon = PauseIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+
+  experiments = signal<ChaosExperiment[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+  toggling = signal<string | null>(null);
+
+  newExp = {
+    name: '',
+    type: 'latency' as ChaosExperiment['type'],
+    target: '',
+    config: '{}'
+  };
+
+  expTypes: Array<{ value: string; label: string }> = [
+    { value: 'latency', label: 'Latency Injection' },
+    { value: 'error', label: 'Error Injection' },
+    { value: 'crash', label: 'Crash' },
+    { value: 'partition', label: 'Network Partition' },
+    { value: 'resource', label: 'Resource Exhaustion' },
+  ];
+
+  ngOnInit(): void { this.loadExperiments(); }
+
+  loadExperiments(): void {
+    this.loading.set(true);
+    this.store.listChaosExperiments().subscribe({
+      next: (data) => {
+        this.experiments.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load chaos experiments');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createExperiment(): void {
+    if (!this.newExp.name.trim() || !this.newExp.target.trim()) return;
+    this.creating.set(true);
+    let config: Record<string, unknown> = {};
+    try { config = JSON.parse(this.newExp.config); } catch { config = {}; }
+    this.store.createChaosExperiment(this.newExp.name.trim(), this.newExp.type, this.newExp.target.trim(), config).subscribe({
+      next: () => {
+        this.toast.success('Chaos experiment created!');
+        this.newExp = { name: '', type: 'latency', target: '', config: '{}' };
+        this.creating.set(false);
+        this.loadExperiments();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create experiment');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  toggleExperiment(id: string): void {
+    this.toggling.set(id);
+    this.store.toggleChaosExperiment(id).subscribe({
+      next: () => {
+        this.toast.success('Experiment toggled');
+        this.toggling.set(null);
+        this.loadExperiments();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to toggle experiment');
+        this.toggling.set(null);
+      }
+    });
+  }
+
+  deleteExperiment(id: string): void {
+    if (!confirm('Delete this chaos experiment?')) return;
+    this.store.deleteChaosExperiment(id).subscribe({
+      next: () => {
+        this.toast.success('Experiment deleted');
+        this.experiments.update(list => list.filter(e => e.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete experiment')
+    });
+  }
+
+  typeClass(type: string): string {
+    switch (type) {
+      case 'latency': return 'badge-warning';
+      case 'error': return 'badge-danger';
+      case 'crash': return 'badge-danger';
+      case 'partition': return 'badge-info';
+      case 'resource': return 'badge-warning';
+      default: return 'badge-info';
+    }
+  }
+
+  statusClass(status: string): string {
+    switch (status) {
+      case 'running': return 'badge-danger';
+      case 'stopped': return 'badge-warning';
+      case 'completed': return 'badge-success';
+      default: return 'badge-info';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/cicd/cicd.component.html
+++ b/frontend/src/app/pages/cicd/cicd.component.html
@@ -1,0 +1,129 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">CI/CD</h1>
+      <p class="page-subtitle">CI/CD fixtures and test data management</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadFixtures()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <div class="grid-2col" style="margin-bottom:24px">
+    <!-- Create Fixture -->
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Add01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Create Fixture</span>
+      </div>
+      <div class="card-body">
+        <div class="form-grid">
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Name</label>
+            <input [(ngModel)]="newFixtureName" placeholder="test-users-100" />
+          </div>
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Description</label>
+            <input [(ngModel)]="newFixtureDesc" placeholder="100 test user records" />
+          </div>
+          <div class="input-group">
+            <label>Type</label>
+            <select [(ngModel)]="newFixtureType">
+              @for (t of fixtureTypes; track t.value) {
+                <option [value]="t.value">{{ t.label }}</option>
+              }
+            </select>
+          </div>
+        </div>
+        <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newFixtureName.trim() || creating()" (click)="createFixture()">
+          @if (creating()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+          }
+          Create Fixture
+        </button>
+      </div>
+    </div>
+
+    <!-- Generate Test Data -->
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="DatabaseIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Generate Test Data</span>
+      </div>
+      <div class="card-body">
+        <div class="form-grid">
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Record Count</label>
+            <input type="number" [(ngModel)]="genCount" min="1" max="1000000" />
+          </div>
+        </div>
+        <button class="btn btn-success" style="margin-top:14px" [disabled]="generating()" (click)="generateTestData()">
+          @if (generating()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="PlayIcon" [size]="15" [strokeWidth]="1.5" />
+          }
+          Generate
+        </button>
+
+        @if (genStatus().status === 'completed') {
+          <div style="margin-top:12px;padding:10px 14px;background:var(--green-dim);border-radius:8px;font-size:0.85rem">
+            Generated {{ genStatus().records_generated }} records in {{ genStatus().elapsed_ms }}ms
+          </div>
+        } @else if (genStatus().status === 'failed') {
+          <div style="margin-top:12px;padding:10px 14px;background:var(--red-dim);border-radius:8px;font-size:0.85rem;color:var(--red)">
+            Generation failed
+          </div>
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- Fixtures List -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="CpuIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Fixtures</span>
+        <span class="badge badge-info">{{ fixtures().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && fixtures().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (fixtures().length === 0) {
+      <div class="empty-state">No fixtures yet. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="fixtures-table">
+          <thead>
+            <tr><th>Name</th><th>Description</th><th>Type</th><th>Size</th><th>Created</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (f of fixtures(); track f.id) {
+              <tr>
+                <td class="name-cell">{{ f.name }}</td>
+                <td style="color:var(--text-secondary);max-width:250px;overflow:hidden;text-overflow:ellipsis;">{{ f.description }}</td>
+                <td><span class="badge badge-info">{{ f.type }}</span></td>
+                <td class="mono">{{ f.size }}</td>
+                <td class="time-cell">{{ nsToDate(f.created_at) | date:'dd/MM HH:mm' }}</td>
+                <td>
+                  <button class="btn btn-danger btn-sm" (click)="deleteFixture(f.id, f.name)">
+                    <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/cicd/cicd.component.scss
+++ b/frontend/src/app/pages/cicd/cicd.component.scss
@@ -1,0 +1,118 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.fixtures-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}

--- a/frontend/src/app/pages/cicd/cicd.component.ts
+++ b/frontend/src/app/pages/cicd/cicd.component.ts
@@ -1,0 +1,136 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+  PlayIcon,
+  DatabaseIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface CICDFixture {
+  id: string;
+  name: string;
+  description: string;
+  type: 'data' | 'config' | 'schema';
+  size: string;
+  created_at: number;
+}
+
+interface TestDataGeneration {
+  status: 'idle' | 'generating' | 'completed' | 'failed';
+  records_generated: number;
+  elapsed_ms?: number;
+}
+
+@Component({
+  selector: 'app-cicd',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './cicd.component.html',
+  styleUrl: './cicd.component.scss'
+})
+export class CicdComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+  readonly PlayIcon = PlayIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+
+  fixtures = signal<CICDFixture[]>([]);
+  loading = signal(false);
+  generating = signal(false);
+  creating = signal(false);
+
+  genStatus = signal<TestDataGeneration>({ status: 'idle', records_generated: 0 });
+  newFixtureName = '';
+  newFixtureDesc = '';
+  newFixtureType: 'data' | 'config' | 'schema' = 'data';
+
+  fixtureTypes: Array<{ value: string; label: string }> = [
+    { value: 'data', label: 'Test Data' },
+    { value: 'config', label: 'Configuration' },
+    { value: 'schema', label: 'Schema' },
+  ];
+
+  genCount = 1000;
+
+  ngOnInit(): void { this.loadFixtures(); }
+
+  loadFixtures(): void {
+    this.loading.set(true);
+    this.store.listCICDFixtures().subscribe({
+      next: (data) => {
+        this.fixtures.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load CI/CD fixtures');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createFixture(): void {
+    if (!this.newFixtureName.trim()) return;
+    this.creating.set(true);
+    this.store.createCICDFixture(this.newFixtureName.trim(), this.newFixtureDesc.trim(), this.newFixtureType).subscribe({
+      next: () => {
+        this.toast.success('Fixture created!');
+        this.newFixtureName = '';
+        this.newFixtureDesc = '';
+        this.creating.set(false);
+        this.loadFixtures();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create fixture');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  deleteFixture(id: string, name: string): void {
+    if (!confirm(`Delete fixture "${name}"?`)) return;
+    this.store.deleteCICDFixture(id).subscribe({
+      next: () => {
+        this.toast.success('Fixture deleted');
+        this.fixtures.update(list => list.filter(f => f.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete fixture')
+    });
+  }
+
+  generateTestData(): void {
+    this.generating.set(true);
+    this.genStatus.set({ status: 'generating', records_generated: 0 });
+    this.store.generateTestData(this.genCount).subscribe({
+      next: (result) => {
+        this.genStatus.set({ status: 'completed', records_generated: result.records_generated, elapsed_ms: result.elapsed_ms });
+        this.generating.set(false);
+        this.toast.success(`Generated ${result.records_generated} records in ${result.elapsed_ms}ms`);
+      },
+      error: (e) => {
+        this.genStatus.set({ status: 'failed', records_generated: 0 });
+        this.generating.set(false);
+        this.toast.error(e?.error?.message ?? 'Data generation failed');
+      }
+    });
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/compaction/compaction.component.html
+++ b/frontend/src/app/pages/compaction/compaction.component.html
@@ -1,0 +1,114 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Compaction</h1>
+      <p class="page-subtitle">LSM-Tree level compaction and memtable flush management</p>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;">
+      @if (lastRefresh(); as dt) {
+        <span class="badge badge-info">Last: {{ dt | date:'HH:mm:ss' }}</span>
+      }
+      <button class="btn btn-secondary" (click)="loadStats()" [disabled]="loading()">
+        @if (loading()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+        }
+        Refresh
+      </button>
+    </div>
+  </div>
+
+  <!-- Action cards -->
+  <div class="actions-grid">
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="DatabaseIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Memtable</span>
+        <span class="badge badge-info">{{ memRecords() }} records</span>
+      </div>
+      <div class="card-body">
+        <div class="stat-row">
+          <span class="stat-key">WAL Size</span>
+          <span class="stat-val">{{ walKb() }} KB</span>
+        </div>
+        <p style="font-size:0.85rem;color:var(--text-secondary);margin:12px 0;">
+          Force a flush of the current memtable to an SSTable on disk.
+        </p>
+        <button class="btn btn-primary" [disabled]="flushing() || memRecords() === 0" (click)="flushMemtable()">
+          @if (flushing()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="FileEditIcon" [size]="15" [strokeWidth]="1.5" />
+          }
+          {{ flushing() ? 'Flushing...' : 'Flush Memtable' }}
+        </button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="SparklesIcon" [size]="17" [strokeWidth]="1.5" color="var(--green)" />
+        <span class="card-title">Compaction</span>
+        <span class="badge badge-info">{{ levels().length }} levels</span>
+      </div>
+      <div class="card-body">
+        <p style="font-size:0.85rem;color:var(--text-secondary);margin-bottom:12px;">
+          Trigger a full compaction cycle across all levels to merge and rewrite SSTables.
+        </p>
+        <button class="btn btn-primary" [disabled]="compacting()" (click)="triggerCompaction()">
+          @if (compacting()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="HardDriveIcon" [size]="15" [strokeWidth]="1.5" />
+          }
+          {{ compacting() ? 'Compacting...' : 'Trigger Compaction' }}
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Levels table -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">LSM-Tree Levels</span>
+        <span class="badge badge-info">{{ levels().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && levels().length === 0) {
+      <div class="loading-state">
+        <span class="spinner" style="width:28px;height:28px;border-width:3px"></span>
+      </div>
+    } @else if (levels().length === 0) {
+      <div class="empty-state">No level data available. Ensure the backend is running.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="levels-table">
+          <thead>
+            <tr><th>Level</th><th>SSTables</th><th>Size</th><th>Status</th></tr>
+          </thead>
+          <tbody>
+            @for (level of levels(); track level.level) {
+              <tr>
+                <td class="level-cell"><span class="badge badge-warning">L{{ level.level }}</span></td>
+                <td>{{ level.sst_count }}</td>
+                <td class="mono">{{ formatSize(level.size_kb) }}</td>
+                <td>
+                  @if (level.running) {
+                    <span class="badge badge-success">Running</span>
+                  } @else if (level.pending) {
+                    <span class="badge badge-warning">Pending</span>
+                  } @else {
+                    <span class="badge badge-info">Idle</span>
+                  }
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/compaction/compaction.component.scss
+++ b/frontend/src/app/pages/compaction/compaction.component.scss
@@ -1,0 +1,126 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.actions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.stat-key {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.stat-val {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.levels-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.level-cell {
+  font-weight: 600;
+}
+
+.mono {
+  font-family: var(--font-mono);
+}

--- a/frontend/src/app/pages/compaction/compaction.component.ts
+++ b/frontend/src/app/pages/compaction/compaction.component.ts
@@ -1,0 +1,128 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  HardDriveIcon,
+  DatabaseIcon,
+  FileEditIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  SparklesIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface CompactionInfo {
+  level: number;
+  sst_count: number;
+  size_kb: number;
+  running: boolean;
+  pending: boolean;
+}
+
+@Component({
+  selector: 'app-compaction',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './compaction.component.html',
+  styleUrl: './compaction.component.scss'
+})
+export class CompactionComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly HardDriveIcon = HardDriveIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+  readonly FileEditIcon = FileEditIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly SparklesIcon = SparklesIcon;
+
+  levels = signal<CompactionInfo[]>([]);
+  memRecords = signal(0);
+  walKb = signal(0);
+  loading = signal(false);
+  flushing = signal(false);
+  compacting = signal(false);
+  lastRefresh = signal<Date | null>(null);
+
+  ngOnInit(): void { this.loadStats(); }
+
+  loadStats(): void {
+    this.loading.set(true);
+    this.store.getStats().subscribe({
+      next: (data) => {
+        this.parseStats(data);
+        this.lastRefresh.set(new Date());
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load compaction status');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  private parseStats(data: Record<string, unknown>): void {
+    this.memRecords.set(Number(data['mem_records'] ?? 0));
+    this.walKb.set(Number(data['wal_kb'] ?? 0));
+
+    const parsed: CompactionInfo[] = [];
+    const sstable = data['sstable'] as Record<string, unknown> | undefined;
+    if (sstable) {
+      for (let i = 0; i <= 6; i++) {
+        const key = `L${i}`;
+        const level = sstable[key] as Record<string, unknown> | undefined;
+        if (level) {
+          parsed.push({
+            level: i,
+            sst_count: Number(level['files'] ?? level['sst_count'] ?? 0),
+            size_kb: Number(level['size_kb'] ?? 0),
+            running: level['compaction_running'] === true,
+            pending: level['compaction_pending'] === true,
+          });
+        }
+      }
+    }
+    this.levels.set(parsed);
+  }
+
+  flushMemtable(): void {
+    this.flushing.set(true);
+    this.store.flush().subscribe({
+      next: () => {
+        this.toast.success('Memtable flushed successfully!');
+        this.flushing.set(false);
+        this.loadStats();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Flush failed');
+        this.flushing.set(false);
+      }
+    });
+  }
+
+  triggerCompaction(): void {
+    this.compacting.set(true);
+    this.store.compact().subscribe({
+      next: () => {
+        this.toast.success('Compaction triggered successfully!');
+        this.compacting.set(false);
+        this.loadStats();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Compaction failed');
+        this.compacting.set(false);
+      }
+    });
+  }
+
+  formatSize(kb: number): string {
+    if (kb > 1_048_576) return (kb / 1_048_576).toFixed(2) + ' GB';
+    if (kb > 1_024) return (kb / 1_024).toFixed(2) + ' MB';
+    return kb.toFixed(0) + ' KB';
+  }
+}

--- a/frontend/src/app/pages/data-scrubber/data-scrubber.component.html
+++ b/frontend/src/app/pages/data-scrubber/data-scrubber.component.html
@@ -1,0 +1,141 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Data Scrubber</h1>
+      <p class="page-subtitle">Data scrubbing and idempotency key management</p>
+    </div>
+    <button class="btn btn-secondary" (click)="activeTab() === 'scrubber' ? loadScrubberJobs() : loadIdempotencyKeys()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Tabs -->
+  <div class="tabs" style="margin-bottom:24px">
+    <button class="tab" [class.active]="activeTab() === 'scrubber'" (click)="switchTab('scrubber')">Scrubber Jobs</button>
+    <button class="tab" [class.active]="activeTab() === 'idempotency'" (click)="switchTab('idempotency')">Idempotency Keys</button>
+  </div>
+
+  @if (activeTab() === 'scrubber') {
+    <!-- Create Scrubber Job -->
+    <div class="card" style="margin-bottom:24px">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Add01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Create Scrubber Job</span>
+      </div>
+      <div class="card-body">
+        <div class="form-grid">
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Key Pattern (glob)</label>
+            <input [(ngModel)]="newPattern" placeholder="temp:*" />
+          </div>
+          <div class="input-group">
+            <label>Retention (days)</label>
+            <input type="number" [(ngModel)]="newRetention" min="1" max="3650" />
+          </div>
+        </div>
+        <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newPattern.trim() || creating()" (click)="createScrubberJob()">
+          @if (creating()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+          }
+          Create Job
+        </button>
+      </div>
+    </div>
+
+    <!-- Scrubber Jobs List -->
+    <div class="card">
+      <div class="card-header" style="justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span class="card-title">Scrubber Jobs</span>
+          <span class="badge badge-info">{{ scrubberJobs().length }}</span>
+        </div>
+      </div>
+
+      @if (loading() && scrubberJobs().length === 0) {
+        <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+      } @else if (scrubberJobs().length === 0) {
+        <div class="empty-state">No scrubber jobs. Create one above.</div>
+      } @else {
+        <div class="table-wrapper">
+          <table class="scrubber-table">
+            <thead>
+              <tr><th>Pattern</th><th>Retention</th><th>Status</th><th>Scrubbed</th><th>Started</th><th>Actions</th></tr>
+            </thead>
+            <tbody>
+              @for (j of scrubberJobs(); track j.id) {
+                <tr>
+                  <td class="mono name-cell">{{ j.pattern }}</td>
+                  <td>{{ j.retention_days }} days</td>
+                  <td><span class="badge" [ngClass]="statusClass(j.status)">{{ j.status }}</span></td>
+                  <td class="mono">{{ j.records_scrubbed }}</td>
+                  <td class="time-cell">{{ nsToDate(j.started_at) | date:'dd/MM HH:mm' }}</td>
+                  <td>
+                    <button class="btn btn-danger btn-sm" (click)="deleteScrubberJob(j.id)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    </div>
+  }
+
+  @if (activeTab() === 'idempotency') {
+    <!-- Idempotency Keys -->
+    <div class="card">
+      <div class="card-header" style="justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <hugeicons-icon [icon]="Key01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+          <span class="card-title">Idempotency Keys</span>
+          <span class="badge badge-info">{{ idempotencyKeys().length }}</span>
+        </div>
+      </div>
+
+      @if (loading() && idempotencyKeys().length === 0) {
+        <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+      } @else if (idempotencyKeys().length === 0) {
+        <div class="empty-state">No idempotency keys found.</div>
+      } @else {
+        <div class="table-wrapper">
+          <table class="idemp-table">
+            <thead>
+              <tr><th>Key</th><th>Created</th><th>Expires</th><th>TTL</th><th>Used</th><th>Actions</th></tr>
+            </thead>
+            <tbody>
+              @for (k of idempotencyKeys(); track k.key) {
+                <tr>
+                  <td class="mono name-cell">{{ k.key }}</td>
+                  <td class="time-cell">{{ nsToDate(k.created_at) | date:'dd/MM HH:mm' }}</td>
+                  <td class="time-cell">{{ nsToDate(k.expires_at) | date:'dd/MM HH:mm' }}</td>
+                  <td class="mono">{{ k.ttl_sec }}s</td>
+                  <td>
+                    @if (k.used) {
+                      <span class="badge badge-success">Yes</span>
+                    } @else {
+                      <span class="badge badge-warning">No</span>
+                    }
+                  </td>
+                  <td>
+                    <button class="btn btn-danger btn-sm" (click)="deleteIdempotencyKey(k.key)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/data-scrubber/data-scrubber.component.scss
+++ b/frontend/src/app/pages/data-scrubber/data-scrubber.component.scss
@@ -1,0 +1,139 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.tab {
+  padding: 10px 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
+
+  &.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  &:hover:not(.active) {
+    color: var(--text-primary);
+  }
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.scrubber-table, .idemp-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}

--- a/frontend/src/app/pages/data-scrubber/data-scrubber.component.ts
+++ b/frontend/src/app/pages/data-scrubber/data-scrubber.component.ts
@@ -1,0 +1,149 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  Key01Icon,
+  PlayIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface ScrubberJob {
+  id: string;
+  pattern: string;
+  retention_days: number;
+  status: 'running' | 'completed' | 'failed' | 'scheduled';
+  records_scrubbed: number;
+  started_at: number;
+  finished_at?: number;
+}
+
+interface IdempotencyKey {
+  key: string;
+  created_at: number;
+  expires_at: number;
+  ttl_sec: number;
+  used: boolean;
+}
+
+@Component({
+  selector: 'app-data-scrubber',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './data-scrubber.component.html',
+  styleUrl: './data-scrubber.component.scss'
+})
+export class DataScrubberComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly Key01Icon = Key01Icon;
+  readonly PlayIcon = PlayIcon;
+
+  scrubberJobs = signal<ScrubberJob[]>([]);
+  idempotencyKeys = signal<IdempotencyKey[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+  activeTab = signal<'scrubber' | 'idempotency'>('scrubber');
+
+  newPattern = '';
+  newRetention = 90;
+
+  ngOnInit(): void { this.loadScrubberJobs(); }
+
+  loadScrubberJobs(): void {
+    this.loading.set(true);
+    this.store.listScrubberJobs().subscribe({
+      next: (data) => {
+        this.scrubberJobs.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load scrubber jobs');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  loadIdempotencyKeys(): void {
+    this.loading.set(true);
+    this.store.listIdempotencyKeys().subscribe({
+      next: (data) => {
+        this.idempotencyKeys.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load idempotency keys');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createScrubberJob(): void {
+    if (!this.newPattern.trim()) return;
+    this.creating.set(true);
+    this.store.createScrubberJob(this.newPattern.trim(), this.newRetention).subscribe({
+      next: () => {
+        this.toast.success('Scrubber job created!');
+        this.newPattern = '';
+        this.creating.set(false);
+        this.loadScrubberJobs();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create scrubber job');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  deleteScrubberJob(id: string): void {
+    if (!confirm('Delete this scrubber job?')) return;
+    this.store.deleteScrubberJob(id).subscribe({
+      next: () => {
+        this.toast.success('Scrubber job deleted');
+        this.scrubberJobs.update(list => list.filter(j => j.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete scrubber job')
+    });
+  }
+
+  deleteIdempotencyKey(key: string): void {
+    this.store.deleteIdempotencyKey(key).subscribe({
+      next: () => {
+        this.toast.success('Idempotency key deleted');
+        this.idempotencyKeys.update(list => list.filter(k => k.key !== key));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete idempotency key')
+    });
+  }
+
+  switchTab(tab: 'scrubber' | 'idempotency'): void {
+    this.activeTab.set(tab);
+    if (tab === 'scrubber') this.loadScrubberJobs();
+    else this.loadIdempotencyKeys();
+  }
+
+  statusClass(status: string): string {
+    switch (status) {
+      case 'completed': return 'badge-success';
+      case 'running': return 'badge-warning';
+      case 'failed': return 'badge-danger';
+      default: return 'badge-info';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/data-sync/data-sync.component.html
+++ b/frontend/src/app/pages/data-sync/data-sync.component.html
@@ -1,0 +1,104 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Data Sync</h1>
+      <p class="page-subtitle">Multi-model data synchronization management</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadJobs()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Create Sync Job -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Add01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Create Sync Job</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Job Name</label>
+          <input [(ngModel)]="newName" placeholder="sync-users-to-pg" />
+        </div>
+        <div class="input-group">
+          <label>Source</label>
+          <input [(ngModel)]="newSource" placeholder="apexstore://users" />
+        </div>
+        <div class="input-group">
+          <label>Target</label>
+          <input [(ngModel)]="newTarget" placeholder="postgres://host/db" />
+        </div>
+        <div class="input-group">
+          <label>Mode</label>
+          <select [(ngModel)]="newMode">
+            @for (m of modes; track m.value) {
+              <option [value]="m.value">{{ m.label }}</option>
+            }
+          </select>
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newName.trim() || !newSource.trim() || !newTarget.trim() || creating()" (click)="createJob()">
+        @if (creating()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Create Job
+      </button>
+    </div>
+  </div>
+
+  <!-- Sync Jobs List -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="Share08Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Sync Jobs</span>
+        <span class="badge badge-info">{{ jobs().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && jobs().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (jobs().length === 0) {
+      <div class="empty-state">No sync jobs. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="sync-table">
+          <thead>
+            <tr><th>Name</th><th>Source</th><th>Target</th><th>Mode</th><th>Status</th><th>Records</th><th>Started</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (j of jobs(); track j.id) {
+              <tr>
+                <td class="name-cell">{{ j.name }}</td>
+                <td class="mono" style="max-width:150px;overflow:hidden;text-overflow:ellipsis;">{{ j.source }}</td>
+                <td class="mono" style="max-width:150px;overflow:hidden;text-overflow:ellipsis;">{{ j.target }}</td>
+                <td><span class="badge badge-info">{{ j.mode }}</span></td>
+                <td><span class="badge" [ngClass]="statusClass(j.status)">{{ j.status }}</span></td>
+                <td class="mono">{{ j.records_synced }}</td>
+                <td class="time-cell">{{ nsToDate(j.started_at) | date:'dd/MM HH:mm' }}</td>
+                <td>
+                  <div class="action-btns">
+                    <button class="btn btn-sm btn-success" (click)="triggerSync(j.id)" [disabled]="j.status === 'running'">
+                      <hugeicons-icon [icon]="PlayIcon" [size]="14" [strokeWidth]="1.5" /> Sync
+                    </button>
+                    <button class="btn btn-sm btn-danger" (click)="deleteJob(j.id)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/data-sync/data-sync.component.scss
+++ b/frontend/src/app/pages/data-sync/data-sync.component.scss
@@ -1,0 +1,117 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.sync-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}

--- a/frontend/src/app/pages/data-sync/data-sync.component.ts
+++ b/frontend/src/app/pages/data-sync/data-sync.component.ts
@@ -1,0 +1,131 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  PlayIcon,
+  DatabaseIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface SyncJob {
+  id: string;
+  name: string;
+  source: string;
+  target: string;
+  mode: 'full' | 'incremental' | 'snapshot';
+  status: 'running' | 'completed' | 'failed' | 'scheduled';
+  records_synced: number;
+  started_at: number;
+  finished_at?: number;
+}
+
+@Component({
+  selector: 'app-data-sync',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './data-sync.component.html',
+  styleUrl: './data-sync.component.scss'
+})
+export class DataSyncComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly PlayIcon = PlayIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+
+  jobs = signal<SyncJob[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+
+  newName = '';
+  newSource = '';
+  newTarget = '';
+  newMode: 'full' | 'incremental' | 'snapshot' = 'incremental';
+
+  modes: Array<{ value: string; label: string }> = [
+    { value: 'full', label: 'Full Sync' },
+    { value: 'incremental', label: 'Incremental' },
+    { value: 'snapshot', label: 'Snapshot' },
+  ];
+
+  ngOnInit(): void { this.loadJobs(); }
+
+  loadJobs(): void {
+    this.loading.set(true);
+    this.store.listSyncJobs().subscribe({
+      next: (data) => {
+        this.jobs.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load sync jobs');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createJob(): void {
+    if (!this.newName.trim() || !this.newSource.trim() || !this.newTarget.trim()) return;
+    this.creating.set(true);
+    this.store.createSyncJob(this.newName.trim(), this.newSource.trim(), this.newTarget.trim(), this.newMode).subscribe({
+      next: () => {
+        this.toast.success('Sync job created!');
+        this.newName = '';
+        this.creating.set(false);
+        this.loadJobs();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create sync job');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  triggerSync(id: string): void {
+    this.store.triggerSyncJob(id).subscribe({
+      next: () => {
+        this.toast.success('Sync triggered!');
+        this.loadJobs();
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to trigger sync')
+    });
+  }
+
+  deleteJob(id: string): void {
+    if (!confirm('Delete this sync job?')) return;
+    this.store.deleteSyncJob(id).subscribe({
+      next: () => {
+        this.toast.success('Sync job deleted');
+        this.jobs.update(list => list.filter(j => j.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete sync job')
+    });
+  }
+
+  statusClass(status: string): string {
+    switch (status) {
+      case 'completed': return 'badge-success';
+      case 'running': return 'badge-warning';
+      case 'failed': return 'badge-danger';
+      default: return 'badge-info';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/graph/graph.component.html
+++ b/frontend/src/app/pages/graph/graph.component.html
@@ -1,0 +1,138 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Graph View</h1>
+      <p class="page-subtitle">Visualize note connections and relationships</p>
+    </div>
+  </div>
+
+  <!-- Controls -->
+  <div class="card controls-card">
+    <div class="card-body">
+      <div class="controls-row">
+        <div class="input-group" style="flex:1">
+          <label>Note Path</label>
+          <input
+            [(ngModel)]="notePath"
+            placeholder="path/to/note"
+            (keydown.enter)="fetchGraph()"
+          />
+        </div>
+        <div class="input-group" style="width:120px">
+          <label>Depth</label>
+          <div class="depth-selector">
+            @for (d of [1, 2, 3]; track d) {
+              <button
+                class="btn btn-sm"
+                [class.btn-primary]="depth() === d"
+                [class.btn-secondary]="depth() !== d"
+                (click)="setDepth(d)"
+              >
+                {{ d }}
+              </button>
+            }
+          </div>
+        </div>
+        <button class="btn btn-primary" style="align-self:flex-end" (click)="fetchGraph()" [disabled]="!notePath().trim() || loading()">
+          @if (loading()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+          }
+          Fetch Graph
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Results -->
+  @if (loading()) {
+    <div class="loading-state">
+      <span class="spinner" style="width:28px;height:28px;border-width:3px"></span>
+      <p>Loading graph data...</p>
+    </div>
+  } @else if (fetched() && graphData(); as data) {
+    <div class="graph-results">
+      <div class="graph-summary">
+        <span class="badge badge-info">{{ data.nodes.length }} nodes</span>
+        <span class="badge badge-purple">{{ data.edges.length }} edges</span>
+      </div>
+
+      <!-- Nodes table -->
+      <div class="card">
+        <div class="card-header">
+          <hugeicons-icon [icon]="NodeMoveDownIcon" [size]="16" [strokeWidth]="1.5" />
+          <span class="card-title">Nodes</span>
+        </div>
+        <div class="card-body">
+          @if (data.nodes.length === 0) {
+            <div class="empty-state">No nodes found</div>
+          } @else {
+            <div class="table-wrapper">
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Label</th>
+                    <th>Type</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (node of data.nodes; track node.id) {
+                    <tr>
+                      <td class="mono">{{ node.id }}</td>
+                      <td>{{ node.label }}</td>
+                      <td>
+                        @if (node.type) {
+                          <span class="badge badge-info">{{ node.type }}</span>
+                        } @else {
+                          <span class="text-muted">—</span>
+                        }
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Edges table -->
+      <div class="card">
+        <div class="card-header">
+          <hugeicons-icon [icon]="Share08Icon" [size]="16" [strokeWidth]="1.5" />
+          <span class="card-title">Edges</span>
+        </div>
+        <div class="card-body">
+          @if (data.edges.length === 0) {
+            <div class="empty-state">No edges found</div>
+          } @else {
+            <div class="table-wrapper">
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Source</th>
+                    <th>Target</th>
+                    <th>Label</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (edge of data.edges; track $index) {
+                    <tr>
+                      <td class="mono">{{ edge.source }}</td>
+                      <td class="mono">{{ edge.target }}</td>
+                      <td>{{ edge.label ?? '—' }}</td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  } @else if (fetched() && !graphData()) {
+    <div class="empty-state">Enter a note path and click "Fetch Graph" to see connections.</div>
+  }
+</div>

--- a/frontend/src/app/pages/graph/graph.component.scss
+++ b/frontend/src/app/pages/graph/graph.component.scss
@@ -1,0 +1,132 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  margin-bottom: 20px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.controls-card {
+  margin-bottom: 24px;
+}
+
+.controls-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.depth-selector {
+  display: flex;
+  gap: 6px;
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px;
+  gap: 16px;
+  color: var(--text-muted);
+}
+
+.empty-state {
+  padding: 60px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.graph-results {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.graph-summary {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.text-muted {
+  color: var(--text-muted);
+}

--- a/frontend/src/app/pages/graph/graph.component.ts
+++ b/frontend/src/app/pages/graph/graph.component.ts
@@ -1,0 +1,63 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  NodeMoveDownIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService, GraphData } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-graph',
+  standalone: true,
+  imports: [FormsModule, HugeiconsIconComponent],
+  templateUrl: './graph.component.html',
+  styleUrl: './graph.component.scss'
+})
+export class GraphComponent {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon      = RefreshIcon;
+  readonly Share08Icon      = Share08Icon;
+  readonly NodeMoveDownIcon = NodeMoveDownIcon;
+
+  notePath    = signal('');
+  depth       = signal<number>(1);
+  graphData   = signal<GraphData | null>(null);
+  loading     = signal(false);
+  fetched     = signal(false);
+
+  fetchGraph(): void {
+    const path = this.notePath().trim();
+    if (!path) return;
+
+    this.loading.set(true);
+    this.fetched.set(false);
+    this.graphData.set(null);
+
+    this.store.getGraphData(path, this.depth()).subscribe({
+      next: (data) => {
+        this.graphData.set(data);
+        this.fetched.set(true);
+        this.loading.set(false);
+        if (data.nodes.length === 0) {
+          this.toast.info('No graph data found for this note');
+        } else {
+          this.toast.success(`Found ${data.nodes.length} node(s) and ${data.edges.length} edge(s)`);
+        }
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to fetch graph data');
+        this.loading.set(false);
+        this.fetched.set(true);
+      }
+    });
+  }
+
+  setDepth(d: number): void {
+    this.depth.set(d);
+  }
+}

--- a/frontend/src/app/pages/graphql/graphql.component.html
+++ b/frontend/src/app/pages/graphql/graphql.component.html
@@ -1,0 +1,50 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">GraphQL Playground</h1>
+      <p class="page-subtitle">Execute GraphQL queries against the ApexStore API</p>
+    </div>
+  </div>
+
+  <div class="playground-layout">
+    <div class="card editor-card">
+      <div class="card-header">
+        <span class="card-title">Query</span>
+      </div>
+      <div class="card-body">
+        <textarea
+          class="query-editor"
+          [ngModel]="query()"
+          (ngModelChange)="query.set($event)"
+          placeholder="Enter GraphQL query..."
+          spellcheck="false"
+          rows="12"
+        ></textarea>
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-primary" (click)="execute()" [disabled]="!query().trim() || loading()">
+          @if (loading()) {
+            <span class="spinner"></span>
+          }
+          Execute
+        </button>
+      </div>
+    </div>
+
+    <div class="card result-card">
+      <div class="card-header">
+        <span class="card-title">Response</span>
+        @if (result()) {
+          <button class="btn btn-secondary btn-sm" (click)="result.set(null); error.set(false)">Clear</button>
+        }
+      </div>
+      <div class="card-body">
+        @if (result()) {
+          <pre class="result-pre" [class.error]="error()">{{ result() }}</pre>
+        } @else {
+          <div class="empty-state">Execute a query to see the response here.</div>
+        }
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/pages/graphql/graphql.component.scss
+++ b/frontend/src/app/pages/graphql/graphql.component.scss
@@ -1,0 +1,124 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.playground-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-footer {
+  padding: 12px 18px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.query-editor {
+  width: 100%;
+  min-height: 250px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s;
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-dim);
+  }
+
+  &::placeholder {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+}
+
+.result-pre {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  font-family: var(--font-mono);
+  font-size: 0.825rem;
+  line-height: 1.5;
+  color: var(--green);
+  overflow: auto;
+  max-height: 500px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+
+  &.error {
+    color: var(--red);
+  }
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}

--- a/frontend/src/app/pages/graphql/graphql.component.ts
+++ b/frontend/src/app/pages/graphql/graphql.component.ts
@@ -1,0 +1,41 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-graphql',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './graphql.component.html',
+  styleUrl: './graphql.component.scss'
+})
+export class GraphQLComponent {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  query = signal(`{\n  stats {\n    total_records\n    sst_files\n    mem_records\n  }\n}`);
+  result = signal<string | null>(null);
+  error = signal(false);
+  loading = signal(false);
+
+  execute(): void {
+    if (!this.query().trim()) return;
+    this.loading.set(true);
+    this.result.set(null);
+    this.error.set(false);
+    this.store.executeGraphQL(this.query().trim()).subscribe({
+      next: (res) => {
+        this.result.set(JSON.stringify(res, null, 2));
+        this.loading.set(false);
+      },
+      error: (err) => {
+        const msg = err?.error?.message ?? err.message ?? 'GraphQL request failed';
+        this.result.set(JSON.stringify({ error: msg }, null, 2));
+        this.error.set(true);
+        this.loading.set(false);
+        this.toast.error(msg);
+      }
+    });
+  }
+}

--- a/frontend/src/app/pages/health/health.component.html
+++ b/frontend/src/app/pages/health/health.component.html
@@ -1,0 +1,52 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Health</h1>
+      <p class="page-subtitle">Health probe status for the ApexStore backend</p>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;">
+      @if (lastCheck(); as dt) {
+        <span class="badge badge-info">Last: {{ dt | date:'HH:mm:ss' }}</span>
+      }
+      <button class="btn btn-primary" (click)="checkAll()" [disabled]="loading()">
+        @if (loading()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+        }
+        Check All
+      </button>
+    </div>
+  </div>
+
+  <!-- Overall status banner -->
+  <div class="overall-banner" [class.healthy]="overall() === 'healthy'" [class.degraded]="overall() === 'degraded'" [class.unhealthy]="overall() === 'unhealthy'">
+    <hugeicons-icon [icon]="overall() === 'healthy' ? CheckmarkCircle01Icon : CancelCircleIcon" [size]="28" [strokeWidth]="1.5" />
+    <div>
+      <strong>{{ overall() === 'healthy' ? 'All Systems Operational' : overall() === 'degraded' ? 'Degraded Service' : 'Service Unavailable' }}</strong>
+      <p>{{ overall() === 'healthy' ? 'All health probes are passing' : overall() === 'degraded' ? 'Some health probes are failing' : 'Backend may be down' }}</p>
+    </div>
+  </div>
+
+  <!-- Probe cards -->
+  <div class="probes-grid">
+    @for (probe of probes(); track probe.name) {
+      <div class="probe-card" [class.healthy]="probe.status === 'healthy'" [class.unhealthy]="probe.status === 'unhealthy'" [class.unknown]="probe.status === 'unknown'">
+        <div class="probe-header">
+          <hugeicons-icon [icon]="probe.icon" [size]="20" [strokeWidth]="1.5" />
+          <span class="probe-name">{{ probe.name }}</span>
+          <span class="badge" [class.badge-success]="probe.status === 'healthy'" [class.badge-danger]="probe.status === 'unhealthy'" [class.badge-info]="probe.status === 'unknown'">
+            {{ probe.status | uppercase }}
+          </span>
+        </div>
+        <p class="probe-message">{{ probe.message }}</p>
+        <div class="probe-footer">
+          <span class="probe-endpoint">{{ probe.endpoint }}</span>
+          <button class="btn btn-secondary btn-sm" (click)="checkProbe(probe)" [disabled]="loading()">
+            <hugeicons-icon [icon]="RefreshIcon" [size]="12" [strokeWidth]="1.5" /> Check
+          </button>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/health/health.component.scss
+++ b/frontend/src/app/pages/health/health.component.scss
@@ -1,0 +1,124 @@
+.page {
+  padding: 32px;
+  max-width: 1000px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.overall-banner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
+  border-radius: var(--radius-lg);
+  margin-bottom: 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+
+  strong {
+    display: block;
+    font-size: 1.1rem;
+    margin-bottom: 2px;
+  }
+
+  p {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  &.healthy {
+    border-left: 4px solid var(--green);
+    color: var(--green);
+  }
+
+  &.degraded {
+    border-left: 4px solid var(--accent);
+    color: var(--accent);
+  }
+
+  &.unhealthy {
+    border-left: 4px solid var(--red);
+    color: var(--red);
+  }
+}
+
+.probes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.probe-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: border-color 0.15s;
+
+  &.healthy {
+    border-left: 3px solid var(--green);
+  }
+
+  &.unhealthy {
+    border-left: 3px solid var(--red);
+  }
+
+  &.unknown {
+    border-left: 3px solid var(--text-muted);
+  }
+}
+
+.probe-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.probe-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  flex: 1;
+}
+
+.probe-message {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.probe-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.probe-endpoint {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}

--- a/frontend/src/app/pages/health/health.component.ts
+++ b/frontend/src/app/pages/health/health.component.ts
@@ -1,0 +1,110 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+  DatabaseIcon,
+  Share08Icon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface HealthProbe {
+  name: string;
+  endpoint: string;
+  status: 'healthy' | 'unhealthy' | 'unknown';
+  message: string;
+  icon: typeof RefreshIcon;
+}
+
+@Component({
+  selector: 'app-health',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './health.component.html',
+  styleUrl: './health.component.scss'
+})
+export class HealthComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+  readonly Share08Icon = Share08Icon;
+
+  probes = signal<HealthProbe[]>([
+    { name: 'Liveness', endpoint: '/health/live', status: 'unknown', message: 'Checking...', icon: CpuIcon },
+    { name: 'Readiness', endpoint: '/health/ready', status: 'unknown', message: 'Checking...', icon: DatabaseIcon },
+    { name: 'Startup', endpoint: '/health/startup', status: 'unknown', message: 'Checking...', icon: Share08Icon },
+  ]);
+
+  overall = signal<'healthy' | 'degraded' | 'unhealthy'>('unknown');
+  loading = signal(false);
+  lastCheck = signal<Date | null>(null);
+
+  ngOnInit(): void { this.checkAll(); }
+
+  checkAll(): void {
+    this.loading.set(true);
+    this.store.getHealth().subscribe({
+      next: () => {
+        this.probes.update(list => list.map(p => ({
+          ...p,
+          status: 'healthy' as const,
+          message: 'Endpoint responding normally',
+        })));
+        this.overall.set('healthy');
+        this.lastCheck.set(new Date());
+        this.loading.set(false);
+        this.toast.success('All health probes passed');
+      },
+      error: () => {
+        this.probes.update(list => list.map(p => ({
+          ...p,
+          status: 'unhealthy' as const,
+          message: 'Health endpoint unreachable',
+        })));
+        this.overall.set('unhealthy');
+        this.lastCheck.set(new Date());
+        this.loading.set(false);
+        this.toast.error('Health check failed - backend may be down');
+      }
+    });
+  }
+
+  checkProbe(probe: HealthProbe): void {
+    this.probes.update(list => list.map(p =>
+      p.name === probe.name ? { ...p, status: 'unknown' as const, message: 'Checking...' } : p
+    ));
+
+    this.store.getHealth().subscribe({
+      next: () => {
+        this.probes.update(list => list.map(p =>
+          p.name === probe.name ? { ...p, status: 'healthy' as const, message: 'Endpoint responding' } : p
+        ));
+        this.updateOverall();
+      },
+      error: () => {
+        this.probes.update(list => list.map(p =>
+          p.name === probe.name ? { ...p, status: 'unhealthy' as const, message: 'Unreachable' } : p
+        ));
+        this.updateOverall();
+      }
+    });
+  }
+
+  private updateOverall(): void {
+    const all = this.probes();
+    const unhealthy = all.filter(p => p.status === 'unhealthy').length;
+    if (unhealthy === 0) this.overall.set('healthy');
+    else if (unhealthy < all.length) this.overall.set('degraded');
+    else this.overall.set('unhealthy');
+  }
+}

--- a/frontend/src/app/pages/notes/notes.component.html
+++ b/frontend/src/app/pages/notes/notes.component.html
@@ -1,0 +1,92 @@
+<div class="page notes-layout">
+  <!-- Left sidebar: file explorer -->
+  <aside class="notes-sidebar">
+    <div class="sidebar-header">
+      <h3>Notes</h3>
+      <div style="display:flex;gap:6px;">
+        <button class="btn btn-secondary btn-sm" (click)="loadNotes()" [disabled]="loadingList()">
+          @if (loadingList()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="RefreshIcon" [size]="14" [strokeWidth]="1.5" />
+          }
+        </button>
+        <button class="btn btn-primary btn-sm" (click)="showNewInput.set(true)">
+          <hugeicons-icon [icon]="Add01Icon" [size]="14" [strokeWidth]="1.5" />
+        </button>
+      </div>
+    </div>
+
+    @if (showNewInput()) {
+      <div class="new-note-form">
+        <input
+          [(ngModel)]="newNotePath"
+          placeholder="path/to/note"
+          (keydown.enter)="createNote()"
+          (keydown.escape)="showNewInput.set(false)"
+          autofocus
+        />
+        <div class="new-note-actions">
+          <button class="btn btn-primary btn-sm" (click)="createNote()" [disabled]="!newNotePath().trim()">Create</button>
+          <button class="btn btn-secondary btn-sm" (click)="showNewInput.set(false)">Cancel</button>
+        </div>
+      </div>
+    }
+
+    <div class="notes-list">
+      @if (notes().length === 0 && !loadingList()) {
+        <div class="empty-state">No notes yet. Click + to create one.</div>
+      }
+      @for (note of notes(); track note.path) {
+        <div
+          class="note-item"
+          [class.active]="selectedNote()?.path === note.path"
+          (click)="selectNote(note)"
+        >
+          <hugeicons-icon [icon]="NoteEditIcon" [size]="14" [strokeWidth]="1.5" />
+          <span class="note-path">{{ note.path }}</span>
+        </div>
+      }
+    </div>
+  </aside>
+
+  <!-- Main area: editor -->
+  <main class="notes-editor">
+    @if (selectedNote(); as note) {
+      <div class="editor-header">
+        <div>
+          <h2 class="editor-title">{{ note.path }}</h2>
+          @if (note.updated_at) {
+            <span class="editor-meta">Last updated: {{ note.updated_at | date:'medium' }}</span>
+          }
+        </div>
+        <div class="editor-actions">
+          <button class="btn btn-success" (click)="saveNote()" [disabled]="loadingSave()">
+            @if (loadingSave()) {
+              <span class="spinner"></span>
+            } @else {
+              <hugeicons-icon [icon]="ArrowRight01Icon" [size]="15" [strokeWidth]="1.5" />
+            }
+            Save
+          </button>
+          <button class="btn btn-danger" (click)="deleteNote()">
+            <hugeicons-icon [icon]="Delete01Icon" [size]="15" [strokeWidth]="1.5" />
+            Delete
+          </button>
+        </div>
+      </div>
+      <div class="editor-body">
+        <textarea
+          [(ngModel)]="noteContent"
+          placeholder="Write your markdown content here..."
+          class="editor-textarea"
+        ></textarea>
+      </div>
+    } @else {
+      <div class="editor-empty">
+        <hugeicons-icon [icon]="NoteEditIcon" [size]="48" [strokeWidth]="1" />
+        <p>Select a note from the sidebar or create a new one</p>
+      </div>
+    }
+  </main>
+</div>

--- a/frontend/src/app/pages/notes/notes.component.scss
+++ b/frontend/src/app/pages/notes/notes.component.scss
@@ -1,0 +1,193 @@
+.page {
+  height: 100%;
+  padding: 0;
+  overflow: hidden;
+}
+
+.notes-layout {
+  display: flex;
+  height: 100%;
+}
+
+.notes-sidebar {
+  width: 260px;
+  min-width: 260px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--border);
+
+  h3 {
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+  }
+}
+
+.new-note-form {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--bg-card);
+
+  input {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 8px 12px;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    font-family: var(--font-mono);
+    outline: none;
+
+    &:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-dim);
+    }
+  }
+}
+
+.new-note-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.notes-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.note-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+
+  &:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+  }
+
+  &.active {
+    background: var(--accent-dim);
+    color: var(--accent);
+  }
+}
+
+.note-path {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notes-editor {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+
+.editor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 28px 16px;
+  border-bottom: 1px solid var(--border);
+  gap: 16px;
+}
+
+.editor-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+
+.editor-meta {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+  display: block;
+}
+
+.editor-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.editor-body {
+  flex: 1;
+  padding: 20px 28px;
+  overflow-y: auto;
+}
+
+.editor-textarea {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.7;
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s;
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-dim);
+  }
+
+  &::placeholder {
+    color: var(--text-muted);
+    font-family: var(--font-sans);
+  }
+}
+
+.editor-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  color: var(--text-muted);
+
+  p {
+    font-size: 0.9rem;
+  }
+}
+
+.empty-state {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}

--- a/frontend/src/app/pages/notes/notes.component.ts
+++ b/frontend/src/app/pages/notes/notes.component.ts
@@ -1,0 +1,99 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  NoteEditIcon,
+  Add01Icon,
+  Delete01Icon,
+  ArrowRight01Icon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService, Note } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-notes',
+  standalone: true,
+  imports: [FormsModule, HugeiconsIconComponent],
+  templateUrl: './notes.component.html',
+  styleUrl: './notes.component.scss'
+})
+export class NotesComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon       = RefreshIcon;
+  readonly NoteEditIcon      = NoteEditIcon;
+  readonly Add01Icon         = Add01Icon;
+  readonly Delete01Icon      = Delete01Icon;
+  readonly ArrowRight01Icon  = ArrowRight01Icon;
+
+  notes          = signal<Note[]>([]);
+  selectedNote   = signal<Note | null>(null);
+  noteContent    = signal('');
+  loadingList    = signal(false);
+  loadingSave    = signal(false);
+  newNotePath    = signal('');
+  showNewInput   = signal(false);
+
+  ngOnInit(): void { this.loadNotes(); }
+
+  loadNotes(): void {
+    this.loadingList.set(true);
+    this.store.getNotes().subscribe({
+      next: (data) => { this.notes.set(data); this.loadingList.set(false); },
+      error: (e) => { this.toast.error(e?.error?.message ?? 'Failed to load notes'); this.loadingList.set(false); }
+    });
+  }
+
+  selectNote(note: Note): void {
+    this.selectedNote.set(note);
+    this.noteContent.set(note.content);
+  }
+
+  saveNote(): void {
+    const note = this.selectedNote();
+    if (!note) return;
+    this.loadingSave.set(true);
+    this.store.putNote(note.path, this.noteContent()).subscribe({
+      next: () => {
+        this.toast.success(`Note "${note.path}" saved`);
+        this.selectedNote.update(n => n ? { ...n, content: this.noteContent() } : n);
+        this.loadNotes();
+        this.loadingSave.set(false);
+      },
+      error: (e) => { this.toast.error(e?.error?.message ?? 'Failed to save note'); this.loadingSave.set(false); }
+    });
+  }
+
+  deleteNote(): void {
+    const note = this.selectedNote();
+    if (!note) return;
+    if (!confirm(`Delete note "${note.path}"?`)) return;
+    this.store.deleteNote(note.path).subscribe({
+      next: () => {
+        this.toast.success(`Note "${note.path}" deleted`);
+        this.selectedNote.set(null);
+        this.noteContent.set('');
+        this.loadNotes();
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete note')
+    });
+  }
+
+  createNote(): void {
+    const path = this.newNotePath().trim();
+    if (!path) return;
+    this.loadingSave.set(true);
+    this.store.putNote(path, '').subscribe({
+      next: () => {
+        this.toast.success(`Note "${path}" created`);
+        this.newNotePath.set('');
+        this.showNewInput.set(false);
+        this.loadNotes();
+        this.loadingSave.set(false);
+      },
+      error: (e) => { this.toast.error(e?.error?.message ?? 'Failed to create note'); this.loadingSave.set(false); }
+    });
+  }
+}

--- a/frontend/src/app/pages/pubsub/pubsub.component.html
+++ b/frontend/src/app/pages/pubsub/pubsub.component.html
@@ -1,0 +1,110 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Pub/Sub</h1>
+      <p class="page-subtitle">Topic inspector and message publisher</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadData()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Publish message -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="ArrowRight01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Publish Message</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Topic</label>
+          <input [(ngModel)]="publishTopic" placeholder="my.topic" />
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Message</label>
+          <textarea [(ngModel)]="publishMessage" placeholder="Message payload..."></textarea>
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="!publishTopic.trim() || !publishMessage.trim() || publishing()" (click)="publishMessage()">
+        @if (publishing()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="ArrowRight01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Publish
+      </button>
+    </div>
+  </div>
+
+  <!-- Topics grid -->
+  <div class="topics-section">
+    <h2 class="section-title">Topics</h2>
+    @if (loading() && topics().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (topics().length === 0) {
+      <div class="empty-state">No topics yet. Publish a message to create one.</div>
+    } @else {
+      <div class="topics-grid">
+        @for (topic of topics(); track topic.name) {
+          <div class="topic-card" [class.selected]="selectedTopic() === topic.name" (click)="loadSubscriptions(topic.name)">
+            <div class="topic-header">
+              <hugeicons-icon [icon]="Share08Icon" [size]="18" [strokeWidth]="1.5" />
+              <span class="topic-name">{{ topic.name }}</span>
+            </div>
+            <div class="topic-stats">
+              <span class="badge badge-info">{{ topic.message_count }} messages</span>
+              @if (topic.last_message_at) {
+                <span class="topic-time">{{ nsToDate(topic.last_message_at) | date:'HH:mm:ss' }}</span>
+              }
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  <!-- Subscriptions for selected topic -->
+  @if (selectedTopic(); as topic) {
+    <div class="card" style="margin-top:24px">
+      <div class="card-header" style="justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <hugeicons-icon [icon]="PackageIcon" [size]="17" [strokeWidth]="1.5" />
+          <span class="card-title">Subscriptions: {{ topic }}</span>
+          <span class="badge badge-info">{{ subscriptions().length }}</span>
+        </div>
+      </div>
+      @if (subscriptions().length === 0) {
+        <div class="empty-state">No subscriptions for this topic.</div>
+      } @else {
+        <div class="table-wrapper">
+          <table class="subs-table">
+            <thead>
+              <tr><th>ID</th><th>Endpoint</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              @for (sub of subscriptions(); track sub.id) {
+                <tr>
+                  <td class="mono">{{ sub.id.substring(0, 12) }}...</td>
+                  <td class="mono">{{ sub.endpoint }}</td>
+                  <td>
+                    @if (sub.active) {
+                      <span class="badge badge-success">Active</span>
+                    } @else {
+                      <span class="badge badge-danger">Inactive</span>
+                    }
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/pubsub/pubsub.component.scss
+++ b/frontend/src/app/pages/pubsub/pubsub.component.scss
@@ -1,0 +1,159 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.topics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.topic-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &:hover {
+    border-color: var(--border-light);
+    background: var(--bg-card-hover);
+  }
+
+  &.selected {
+    border-color: var(--accent);
+    background: var(--accent-dim);
+  }
+}
+
+.topic-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.topic-name {
+  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.topic-stats {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.topic-time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.subs-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.mono {
+  font-family: var(--font-mono);
+}

--- a/frontend/src/app/pages/pubsub/pubsub.component.ts
+++ b/frontend/src/app/pages/pubsub/pubsub.component.ts
@@ -1,0 +1,107 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  ArrowRight01Icon,
+  PackageIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface Topic {
+  name: string;
+  message_count: number;
+  last_message_at?: number;
+}
+
+interface Subscription {
+  id: string;
+  topic: string;
+  endpoint: string;
+  active: boolean;
+}
+
+@Component({
+  selector: 'app-pubsub',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './pubsub.component.html',
+  styleUrl: './pubsub.component.scss'
+})
+export class PubsubComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly ArrowRight01Icon = ArrowRight01Icon;
+  readonly PackageIcon = PackageIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+
+  topics = signal<Topic[]>([]);
+  subscriptions = signal<Subscription[]>([]);
+  loading = signal(false);
+  publishing = signal(false);
+
+  publishTopic = '';
+  publishMessage = '';
+  selectedTopic = signal<string | null>(null);
+
+  ngOnInit(): void { this.loadData(); }
+
+  loadData(): void {
+    this.loading.set(true);
+    this.store.listTopics().subscribe({
+      next: (data) => {
+        this.topics.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load topics');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  loadSubscriptions(topic: string): void {
+    this.selectedTopic.set(topic);
+    this.store.listSubscriptions(topic).subscribe({
+      next: (data) => {
+        this.subscriptions.set(data);
+      },
+      error: () => {
+        this.toast.error('Failed to load subscriptions');
+      }
+    });
+  }
+
+  publishMessage(): void {
+    const topic = this.publishTopic.trim();
+    const message = this.publishMessage.trim();
+    if (!topic || !message) return;
+
+    this.publishing.set(true);
+    this.store.publishMessage(topic, message).subscribe({
+      next: () => {
+        this.toast.success(`Message published to "${topic}"!`);
+        this.publishMessage = '';
+        this.publishing.set(false);
+        this.loadData();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Publish failed');
+        this.publishing.set(false);
+      }
+    });
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/quotas/quotas.component.html
+++ b/frontend/src/app/pages/quotas/quotas.component.html
@@ -1,0 +1,137 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Quotas</h1>
+      <p class="page-subtitle">Tenant quotas and query budget management</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadQuotas()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Quota Form -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      @if (editingId()) {
+        <span class="card-title">Edit Quota</span>
+      } @else {
+        <span class="card-title">Create Quota</span>
+      }
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Tenant</label>
+          <input [(ngModel)]="form.tenant" placeholder="tenant-01" [disabled]="!!editingId()" />
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Description</label>
+          <input [(ngModel)]="form.description" placeholder="Production tenant" />
+        </div>
+        <div class="input-group">
+          <label>Max Requests/sec</label>
+          <input type="number" [(ngModel)]="form.max_requests_per_sec" min="0" />
+        </div>
+        <div class="input-group">
+          <label>Max Reads/sec</label>
+          <input type="number" [(ngModel)]="form.max_reads_per_sec" min="0" />
+        </div>
+        <div class="input-group">
+          <label>Max Writes/sec</label>
+          <input type="number" [(ngModel)]="form.max_writes_per_sec" min="0" />
+        </div>
+        <div class="input-group">
+          <label>Max Storage (MB)</label>
+          <input type="number" [(ngModel)]="form.max_storage_mb" min="0" />
+        </div>
+        <div class="input-group">
+          <label>Daily Budget</label>
+          <input type="number" [(ngModel)]="form.max_budget_per_day" min="0" />
+        </div>
+        <div class="input-group">
+          <label>Active</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="form.active" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;margin-top:14px">
+        @if (editingId()) {
+          <button class="btn btn-primary" [disabled]="saving()" (click)="updateQuota()">
+            @if (saving()) { <span class="spinner"></span> }
+            @else { <hugeicons-icon [icon]="CheckmarkCircle01Icon" [size]="15" [strokeWidth]="1.5" /> }
+            Update Quota
+          </button>
+          <button class="btn btn-secondary" (click)="resetForm()">Cancel</button>
+        } @else {
+          <button class="btn btn-primary" [disabled]="!form.tenant?.trim() || saving()" (click)="saveQuota()">
+            @if (saving()) { <span class="spinner"></span> }
+            @else { <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" /> }
+            Create Quota
+          </button>
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- Quotas List -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="DatabaseIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Quotas</span>
+        <span class="badge badge-info">{{ quotas().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && quotas().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (quotas().length === 0) {
+      <div class="empty-state">No quotas configured. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="quotas-table">
+          <thead>
+            <tr><th>Tenant</th><th>Requests/s</th><th>Reads/s</th><th>Writes/s</th><th>Storage</th><th>Budget</th><th>Used</th><th>Status</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (q of quotas(); track q.id) {
+              <tr>
+                <td class="name-cell">{{ q.tenant }}</td>
+                <td class="mono">{{ q.max_requests_per_sec }}</td>
+                <td class="mono">{{ q.max_reads_per_sec }}</td>
+                <td class="mono">{{ q.max_writes_per_sec }}</td>
+                <td class="mono">{{ q.max_storage_mb }} MB</td>
+                <td class="mono">{{ q.max_budget_per_day }}</td>
+                <td class="mono">{{ q.current_budget_used }}</td>
+                <td>
+                  @if (q.active) {
+                    <span class="badge badge-success">Active</span>
+                  } @else {
+                    <span class="badge badge-danger">Inactive</span>
+                  }
+                </td>
+                <td>
+                  <div class="action-btns">
+                    <button class="btn btn-sm btn-secondary" (click)="editQuota(q)">
+                      <hugeicons-icon [icon]="Edit01Icon" [size]="14" [strokeWidth]="1.5" /> Edit
+                    </button>
+                    <button class="btn btn-sm btn-danger" (click)="deleteQuota(q.id, q.tenant)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/quotas/quotas.component.scss
+++ b/frontend/src/app/pages/quotas/quotas.component.scss
@@ -1,0 +1,147 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+
+  input { display: none; }
+
+  .toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: var(--border);
+    border-radius: 24px;
+    transition: 0.2s;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: white;
+      border-radius: 50%;
+      transition: 0.2s;
+    }
+  }
+
+  input:checked + .toggle-slider {
+    background: var(--accent);
+
+    &::before { transform: translateX(20px); }
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.quotas-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}

--- a/frontend/src/app/pages/quotas/quotas.component.ts
+++ b/frontend/src/app/pages/quotas/quotas.component.ts
@@ -1,0 +1,142 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Add01Icon,
+  Delete01Icon,
+  Settings01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  DatabaseIcon,
+  Edit01Icon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface Quota {
+  id: string;
+  tenant: string;
+  description: string;
+  max_requests_per_sec: number;
+  max_reads_per_sec: number;
+  max_writes_per_sec: number;
+  max_storage_mb: number;
+  max_budget_per_day: number;
+  current_budget_used: number;
+  active: boolean;
+  created_at: number;
+}
+
+@Component({
+  selector: 'app-quotas',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './quotas.component.html',
+  styleUrl: './quotas.component.scss'
+})
+export class QuotasComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly Settings01Icon = Settings01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+  readonly Edit01Icon = Edit01Icon;
+
+  quotas = signal<Quota[]>([]);
+  loading = signal(false);
+  saving = signal(false);
+  editingId = signal<string | null>(null);
+
+  form: Partial<Quota> = {
+    tenant: '',
+    description: '',
+    max_requests_per_sec: 1000,
+    max_reads_per_sec: 500,
+    max_writes_per_sec: 200,
+    max_storage_mb: 1024,
+    max_budget_per_day: 10000,
+    active: true,
+  };
+
+  ngOnInit(): void { this.loadQuotas(); }
+
+  loadQuotas(): void {
+    this.loading.set(true);
+    this.store.listQuotas().subscribe({
+      next: (data) => {
+        this.quotas.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load quotas');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  saveQuota(): void {
+    if (!this.form.tenant?.trim()) return;
+    this.saving.set(true);
+    this.store.createQuota(this.form as Quota).subscribe({
+      next: () => {
+        this.toast.success('Quota saved!');
+        this.resetForm();
+        this.saving.set(false);
+        this.loadQuotas();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to save quota');
+        this.saving.set(false);
+      }
+    });
+  }
+
+  editQuota(q: Quota): void {
+    this.form = { ...q };
+    this.editingId.set(q.id);
+  }
+
+  updateQuota(): void {
+    if (!this.editingId() || !this.form.tenant?.trim()) return;
+    this.saving.set(true);
+    this.store.updateQuota(this.editingId()!, this.form).subscribe({
+      next: () => {
+        this.toast.success('Quota updated!');
+        this.resetForm();
+        this.saving.set(false);
+        this.loadQuotas();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to update quota');
+        this.saving.set(false);
+      }
+    });
+  }
+
+  deleteQuota(id: string, tenant: string): void {
+    if (!confirm(`Delete quota for "${tenant}"?`)) return;
+    this.store.deleteQuota(id).subscribe({
+      next: () => {
+        this.toast.success('Quota deleted');
+        this.quotas.update(list => list.filter(q => q.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete quota')
+    });
+  }
+
+  resetForm(): void {
+    this.form = { tenant: '', description: '', max_requests_per_sec: 1000, max_reads_per_sec: 500, max_writes_per_sec: 200, max_storage_mb: 1024, max_budget_per_day: 10000, active: true };
+    this.editingId.set(null);
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/rate-limits/rate-limits.component.html
+++ b/frontend/src/app/pages/rate-limits/rate-limits.component.html
@@ -1,0 +1,67 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Rate Limits</h1>
+      <p class="page-subtitle">Current rate limit state for API endpoints</p>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;">
+      @if (lastRefresh(); as dt) {
+        <span class="badge badge-info">Last: {{ dt | date:'HH:mm:ss' }}</span>
+      }
+      <button class="btn btn-secondary" (click)="loadLimits()" [disabled]="loading()">
+        @if (loading()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+        }
+        Refresh
+      </button>
+    </div>
+  </div>
+
+  @if (loading() && limits().length === 0) {
+    <div class="loading-state">
+      <span class="spinner" style="width:28px;height:28px;border-width:3px"></span>
+    </div>
+  } @else if (limits().length === 0) {
+    <div class="empty-state">No rate limits configured or endpoint unavailable.</div>
+  } @else {
+    <div class="limits-grid">
+      @for (entry of limits(); track entry.name) {
+        <div class="limit-card" [class.near-limit]="usagePercent(entry) >= 80" [class.at-limit]="entry.remaining === 0">
+          <div class="limit-header">
+            <hugeicons-icon [icon]="BarChartIcon" [size]="18" [strokeWidth]="1.5" />
+            <span class="limit-name">{{ entry.name }}</span>
+          </div>
+          <div class="limit-stats">
+            <div class="limit-stat">
+              <span class="stat-label">Limit</span>
+              <span class="stat-value">{{ entry.limit }}</span>
+            </div>
+            <div class="limit-stat">
+              <span class="stat-label">Remaining</span>
+              <span class="stat-value remaining">{{ entry.remaining }}</span>
+            </div>
+            <div class="limit-stat">
+              <span class="stat-label">Window</span>
+              <span class="stat-value">{{ entry.window_sec }}s</span>
+            </div>
+          </div>
+          <div class="progress-bar-bg">
+            <div class="progress-bar-fill" [style.width.%]="usagePercent(entry)" [class.warning]="usagePercent(entry) >= 80" [class.danger]="entry.remaining === 0"></div>
+          </div>
+          <div class="limit-footer">
+            <span class="reset-label">Resets at {{ resetDate(entry.reset_at) | date:'HH:mm:ss' }}</span>
+            @if (entry.remaining === 0) {
+              <span class="badge badge-danger">Exhausted</span>
+            } @else if (usagePercent(entry) >= 80) {
+              <span class="badge badge-warning">Near limit</span>
+            } @else {
+              <span class="badge badge-success">OK</span>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/rate-limits/rate-limits.component.scss
+++ b/frontend/src/app/pages/rate-limits/rate-limits.component.scss
@@ -1,0 +1,138 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.limits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.limit-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  &.near-limit {
+    border-left: 3px solid var(--accent);
+  }
+
+  &.at-limit {
+    border-left: 3px solid var(--red);
+  }
+}
+
+.limit-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.limit-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.limit-stats {
+  display: flex;
+  gap: 20px;
+}
+
+.limit-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stat-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.stat-value {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+
+  &.remaining {
+    color: var(--green);
+  }
+}
+
+.progress-bar-bg {
+  height: 8px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: var(--green);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+
+  &.warning {
+    background: var(--accent);
+  }
+
+  &.danger {
+    background: var(--red);
+  }
+}
+
+.limit-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.reset-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}

--- a/frontend/src/app/pages/rate-limits/rate-limits.component.ts
+++ b/frontend/src/app/pages/rate-limits/rate-limits.component.ts
@@ -1,0 +1,68 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  BarChartIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface RateLimitEntry {
+  name: string;
+  limit: number;
+  remaining: number;
+  reset_at: number;
+  window_sec: number;
+}
+
+@Component({
+  selector: 'app-rate-limits',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './rate-limits.component.html',
+  styleUrl: './rate-limits.component.scss'
+})
+export class RateLimitsComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly BarChartIcon = BarChartIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+
+  limits = signal<RateLimitEntry[]>([]);
+  loading = signal(false);
+  lastRefresh = signal<Date | null>(null);
+
+  ngOnInit(): void { this.loadLimits(); }
+
+  loadLimits(): void {
+    this.loading.set(true);
+    this.store.getRateLimits().subscribe({
+      next: (data) => {
+        const entries = data['limits'] as RateLimitEntry[] ?? [];
+        this.limits.set(entries);
+        this.lastRefresh.set(new Date());
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load rate limits');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  usagePercent(entry: RateLimitEntry): number {
+    if (entry.limit === 0) return 0;
+    return ((entry.limit - entry.remaining) / entry.limit) * 100;
+  }
+
+  resetDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/replication/replication.component.html
+++ b/frontend/src/app/pages/replication/replication.component.html
@@ -1,0 +1,83 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Replication</h1>
+      <p class="page-subtitle">Replication topology and status monitoring</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadTopology()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  @if (summary(); as s) {
+    <div class="summary-bar">
+      <div class="summary-item" [class.healthy]="s.status === 'healthy'" [class.degraded]="s.status === 'degraded'" [class.critical]="s.status === 'critical'">
+        <span class="summary-label">Status</span>
+        <span class="summary-value">{{ s.status | uppercase }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Connected</span>
+        <span class="summary-value">{{ s.connected }}/{{ s.total }}</span>
+      </div>
+      <div class="summary-item">
+        <span class="summary-label">Avg Lag</span>
+        <span class="summary-value">{{ s.avg_lag_ms }}ms</span>
+      </div>
+    </div>
+  }
+
+  <div class="card" style="margin-top:24px">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="DatabaseIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Cluster Nodes</span>
+        <span class="badge badge-info">{{ nodes().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && nodes().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (nodes().length === 0) {
+      <div class="empty-state">No nodes found in replication topology.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="replication-table">
+          <thead>
+            <tr><th>Name</th><th>Role</th><th>Status</th><th>Lag</th><th>Address</th><th>Last Heartbeat</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (n of nodes(); track n.id) {
+              <tr>
+                <td class="name-cell">{{ n.name }}</td>
+                <td>
+                  <span class="badge" [class.badge-primary]="n.role === 'primary'" [class.badge-info]="n.role === 'secondary'" [class.badge-default]="n.role === 'observer'">
+                    {{ n.role }}
+                  </span>
+                </td>
+                <td>
+                  <span class="badge" [ngClass]="statusClass(n.status)">{{ n.status }}</span>
+                </td>
+                <td class="mono">{{ n.lag_ms }}ms</td>
+                <td class="mono">{{ n.address }}</td>
+                <td class="time-cell">{{ nsToDate(n.last_heartbeat) | date:'HH:mm:ss' }}</td>
+                <td>
+                  <div class="action-btns">
+                    @if (n.role !== 'primary') {
+                      <button class="btn btn-sm btn-primary" (click)="promoteToPrimary(n.id)">Promote</button>
+                    }
+                    <button class="btn btn-sm btn-danger" (click)="removeNode(n.id)">Remove</button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/replication/replication.component.scss
+++ b/frontend/src/app/pages/replication/replication.component.scss
@@ -1,0 +1,144 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.summary-bar {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.summary-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 14px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+  border-left: 3px solid var(--border);
+
+  &.healthy { border-left-color: var(--green); }
+  &.degraded { border-left-color: var(--accent); }
+  &.critical { border-left-color: var(--red); }
+}
+
+.summary-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.summary-value {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.replication-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}

--- a/frontend/src/app/pages/replication/replication.component.ts
+++ b/frontend/src/app/pages/replication/replication.component.ts
@@ -1,0 +1,113 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  DatabaseIcon,
+  CpuIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface ReplicaNode {
+  id: string;
+  name: string;
+  role: 'primary' | 'secondary' | 'observer';
+  status: 'online' | 'offline' | 'syncing';
+  lag_ms: number;
+  address: string;
+  last_heartbeat: number;
+}
+
+interface ReplicationSummary {
+  connected: number;
+  total: number;
+  avg_lag_ms: number;
+  status: 'healthy' | 'degraded' | 'critical';
+}
+
+@Component({
+  selector: 'app-replication',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './replication.component.html',
+  styleUrl: './replication.component.scss'
+})
+export class ReplicationComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+  readonly CpuIcon = CpuIcon;
+
+  nodes = signal<ReplicaNode[]>([]);
+  summary = signal<ReplicationSummary | null>(null);
+  loading = signal(false);
+
+  ngOnInit(): void { this.loadTopology(); }
+
+  loadTopology(): void {
+    this.loading.set(true);
+    this.store.getReplicationTopology().subscribe({
+      next: (data) => {
+        this.nodes.set(data.nodes);
+        this.summary.set(data.summary);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load replication topology');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  promoteToPrimary(id: string): void {
+    if (!confirm('Promote this node to primary?')) return;
+    this.store.promoteReplica(id).subscribe({
+      next: () => {
+        this.toast.success('Node promoted to primary');
+        this.loadTopology();
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Promotion failed')
+    });
+  }
+
+  removeNode(id: string): void {
+    if (!confirm('Remove this node from the cluster?')) return;
+    this.store.removeReplica(id).subscribe({
+      next: () => {
+        this.toast.success('Node removed');
+        this.nodes.update(list => list.filter(n => n.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to remove node')
+    });
+  }
+
+  statusClass(status: string): string {
+    switch (status) {
+      case 'online': return 'badge-success';
+      case 'syncing': return 'badge-warning';
+      default: return 'badge-danger';
+    }
+  }
+
+  roleClass(role: string): string {
+    switch (role) {
+      case 'primary': return 'badge-primary';
+      case 'secondary': return 'badge-info';
+      default: return 'badge-default';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/resilience/resilience.component.html
+++ b/frontend/src/app/pages/resilience/resilience.component.html
@@ -1,0 +1,79 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Resilience</h1>
+      <p class="page-subtitle">Circuit breaker and system health dashboard</p>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;">
+      @if (lastCheck(); as dt) {
+        <span class="badge badge-info">Last: {{ dt | date:'HH:mm:ss' }}</span>
+      }
+      <button class="btn btn-primary" (click)="checkAll()" [disabled]="loading()">
+        @if (loading()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+        }
+        Check All
+      </button>
+    </div>
+  </div>
+
+  <!-- Health Summary -->
+  <h2 class="section-title">System Health</h2>
+  <div class="summary-grid">
+    @for (item of healthSummary(); track item.label) {
+      <div class="summary-card" [class.healthy]="item.status === 'healthy'" [class.degraded]="item.status === 'degraded'" [class.unhealthy]="item.status === 'unhealthy'">
+        <hugeicons-icon [icon]="item.icon" [size]="24" [strokeWidth]="1.5" />
+        <div class="summary-info">
+          <strong>{{ item.label }}</strong>
+          <span>{{ item.message }}</span>
+        </div>
+        <span class="badge" [class.badge-success]="item.status === 'healthy'" [class.badge-warning]="item.status === 'degraded'" [class.badge-danger]="item.status === 'unhealthy'">
+          {{ item.status | uppercase }}
+        </span>
+      </div>
+    }
+  </div>
+
+  <!-- Circuit Breakers -->
+  <h2 class="section-title" style="margin-top:24px">Circuit Breakers</h2>
+  @if (loading() && circuitBreakers().length === 0) {
+    <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+  } @else if (circuitBreakers().length === 0) {
+    <div class="empty-state">No circuit breakers configured or endpoint unavailable.</div>
+  } @else {
+    <div class="breakers-grid">
+      @for (cb of circuitBreakers(); track cb.name) {
+        <div class="breaker-card" [class.open]="cb.state === 'open'" [class.half-open]="cb.state === 'half_open'" [class.closed]="cb.state === 'closed'">
+          <div class="breaker-header">
+            <hugeicons-icon [icon]="ZapIcon" [size]="18" [strokeWidth]="1.5" />
+            <span class="breaker-name">{{ cb.name }}</span>
+            <span class="badge" [class.badge-success]="cb.state === 'closed'" [class.badge-danger]="cb.state === 'open'" [class.badge-warning]="cb.state === 'half_open'">
+              {{ stateLabel(cb.state) }}
+            </span>
+          </div>
+          <div class="breaker-stats">
+            <div class="breaker-stat">
+              <span class="stat-label">Success</span>
+              <span class="stat-value success">{{ cb.success_count }}</span>
+            </div>
+            <div class="breaker-stat">
+              <span class="stat-label">Failures</span>
+              <span class="stat-value failure">{{ cb.failure_count }}</span>
+            </div>
+            <div class="breaker-stat">
+              <span class="stat-label">Threshold</span>
+              <span class="stat-value">{{ cb.threshold }}</span>
+            </div>
+          </div>
+          @if (cb.last_failure_at) {
+            <div class="breaker-footer">
+              <span class="failure-time">Last failure: {{ nsToDate(cb.last_failure_at) | date:'dd/MM HH:mm:ss' }}</span>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/resilience/resilience.component.scss
+++ b/frontend/src/app/pages/resilience/resilience.component.scss
@@ -1,0 +1,149 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+}
+
+.summary-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+
+  &.healthy { border-left: 3px solid var(--green); color: var(--green); }
+  &.degraded { border-left: 3px solid var(--accent); color: var(--accent); }
+  &.unhealthy { border-left: 3px solid var(--red); color: var(--red); }
+
+  .summary-info {
+    flex: 1;
+
+    strong {
+      display: block;
+      font-size: 0.9rem;
+      margin-bottom: 2px;
+    }
+
+    span {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+    }
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.breakers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.breaker-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  &.closed { border-left: 3px solid var(--green); }
+  &.open { border-left: 3px solid var(--red); }
+  &.half-open { border-left: 3px solid var(--accent); }
+}
+
+.breaker-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.breaker-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  flex: 1;
+  font-family: var(--font-mono);
+}
+
+.breaker-stats {
+  display: flex;
+  gap: 20px;
+}
+
+.breaker-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stat-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.stat-value {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 700;
+
+  &.success { color: var(--green); }
+  &.failure { color: var(--red); }
+}
+
+.breaker-footer {
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.failure-time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}

--- a/frontend/src/app/pages/resilience/resilience.component.ts
+++ b/frontend/src/app/pages/resilience/resilience.component.ts
@@ -1,0 +1,117 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+  DatabaseIcon,
+  Share08Icon,
+  ZapIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface CircuitBreaker {
+  name: string;
+  state: 'closed' | 'open' | 'half_open';
+  failure_count: number;
+  success_count: number;
+  threshold: number;
+  last_failure_at?: number;
+}
+
+interface HealthSummary {
+  label: string;
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  message: string;
+  icon: typeof RefreshIcon;
+}
+
+@Component({
+  selector: 'app-resilience',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './resilience.component.html',
+  styleUrl: './resilience.component.scss'
+})
+export class ResilienceComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly ZapIcon = ZapIcon;
+
+  circuitBreakers = signal<CircuitBreaker[]>([]);
+  healthSummary = signal<HealthSummary[]>([
+    { label: 'API Server', status: 'unknown', message: 'Checking...', icon: CpuIcon },
+    { label: 'Storage Engine', status: 'unknown', message: 'Checking...', icon: DatabaseIcon },
+    { label: 'Network', status: 'unknown', message: 'Checking...', icon: Share08Icon },
+  ]);
+  loading = signal(false);
+  lastCheck = signal<Date | null>(null);
+
+  ngOnInit(): void { this.checkAll(); }
+
+  checkAll(): void {
+    this.loading.set(true);
+    this.store.getCircuitBreakers().subscribe({
+      next: (data) => {
+        this.circuitBreakers.set(data);
+        this.loading.set(false);
+        this.lastCheck.set(new Date());
+      },
+      error: () => {
+        this.toast.error('Failed to load circuit breaker state');
+        this.loading.set(false);
+      }
+    });
+
+    // Also check health for summary
+    this.store.getHealth().subscribe({
+      next: () => {
+        this.healthSummary.set([
+          { label: 'API Server', status: 'healthy', message: 'Responding normally', icon: CpuIcon },
+          { label: 'Storage Engine', status: 'healthy', message: 'All operations nominal', icon: DatabaseIcon },
+          { label: 'Network', status: 'healthy', message: 'Connectivity OK', icon: Share08Icon },
+        ]);
+      },
+      error: () => {
+        this.healthSummary.set([
+          { label: 'API Server', status: 'unhealthy', message: 'Unreachable', icon: CpuIcon },
+          { label: 'Storage Engine', status: 'degraded', message: 'Cannot verify', icon: DatabaseIcon },
+          { label: 'Network', status: 'degraded', message: 'Connection lost', icon: Share08Icon },
+        ]);
+      }
+    });
+  }
+
+  stateBadge(state: string): string {
+    switch (state) {
+      case 'closed': return 'badge-success';
+      case 'open': return 'badge-danger';
+      case 'half_open': return 'badge-warning';
+      default: return 'badge-info';
+    }
+  }
+
+  stateLabel(state: string): string {
+    switch (state) {
+      case 'closed': return 'Closed';
+      case 'open': return 'Open';
+      case 'half_open': return 'Half-Open';
+      default: return state;
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/server-config/server-config.component.html
+++ b/frontend/src/app/pages/server-config/server-config.component.html
@@ -1,0 +1,76 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Server Configuration</h1>
+      <p class="page-subtitle">View and manage server configuration parameters</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadConfig()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Filter -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Settings01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Configuration</span>
+      <span class="badge badge-info">{{ filtered().length }}</span>
+    </div>
+    <div class="card-body">
+      <div class="input-group" style="max-width:400px">
+        <label>Filter</label>
+        <input [(ngModel)]="filterText" (ngModelChange)="onFilterChange()" placeholder="Search by key, description, or group..." />
+      </div>
+    </div>
+
+    @if (loading() && config().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (filtered().length === 0) {
+      <div class="empty-state">No configuration entries found.</div>
+    } @else {
+      <div class="table-wrapper">
+        @for (group of getConfigGroups(); track group) {
+          <div class="config-group">
+            <div class="config-group-title">{{ group }}</div>
+            <table class="config-table">
+              <thead>
+                <tr><th>Key</th><th>Value</th><th>Type</th><th>Description</th><th>Mutable</th></tr>
+              </thead>
+              <tbody>
+                @for (entry of filtered().filter(c => c.group === group); track entry.key) {
+                  <tr>
+                    <td class="mono key-cell">{{ entry.key }}</td>
+                    <td class="mono">
+                      @if (entry.mutable) {
+                        <div class="inline-edit">
+                          <input [value]="entry.value" #val (keydown.enter)="updateConfig(entry, val.value)" />
+                          <button class="btn btn-sm btn-primary" (click)="updateConfig(entry, val.value)" [disabled]="saving()">Save</button>
+                        </div>
+                      } @else {
+                        <span class="value-display">{{ entry.value }}</span>
+                      }
+                    </td>
+                    <td><span class="badge badge-info">{{ entry.type }}</span></td>
+                    <td style="color:var(--text-secondary);font-size:0.8rem">{{ entry.description }}</td>
+                    <td>
+                      @if (entry.mutable) {
+                        <span class="badge badge-success">Yes</span>
+                      } @else {
+                        <span class="badge badge-danger">No</span>
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/server-config/server-config.component.scss
+++ b/frontend/src/app/pages/server-config/server-config.component.scss
@@ -1,0 +1,139 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.config-group {
+  border-bottom: 1px solid var(--border);
+
+  &:last-child { border-bottom: none; }
+}
+
+.config-group-title {
+  padding: 12px 18px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+}
+
+.config-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.key-cell {
+  color: var(--accent);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.inline-edit {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+
+  input {
+    width: 200px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+  }
+}
+
+.value-display {
+  color: var(--text-primary);
+}

--- a/frontend/src/app/pages/server-config/server-config.component.ts
+++ b/frontend/src/app/pages/server-config/server-config.component.ts
@@ -1,0 +1,99 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Settings01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface ConfigEntry {
+  key: string;
+  value: string;
+  type: 'string' | 'number' | 'boolean' | 'json';
+  description: string;
+  mutable: boolean;
+  group: string;
+}
+
+@Component({
+  selector: 'app-server-config',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './server-config.component.html',
+  styleUrl: './server-config.component.scss'
+})
+export class ServerConfigComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Settings01Icon = Settings01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+
+  config = signal<ConfigEntry[]>([]);
+  filtered = signal<ConfigEntry[]>([]);
+  loading = signal(false);
+  saving = signal(false);
+  filterText = '';
+
+  ngOnInit(): void { this.loadConfig(); }
+
+  loadConfig(): void {
+    this.loading.set(true);
+    this.store.getServerConfig().subscribe({
+      next: (data) => {
+        this.config.set(data);
+        this.applyFilter();
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load server config');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  applyFilter(): void {
+    const q = this.filterText.toLowerCase();
+    if (!q) {
+      this.filtered.set(this.config());
+    } else {
+      this.filtered.set(this.config().filter(c =>
+        c.key.toLowerCase().includes(q) ||
+        c.description.toLowerCase().includes(q) ||
+        c.group.toLowerCase().includes(q)
+      ));
+    }
+  }
+
+  getConfigGroups(): string[] {
+    const groups = new Set(this.filtered().map(c => c.group));
+    return Array.from(groups).sort();
+  }
+
+  updateConfig(entry: ConfigEntry, newValue: string): void {
+    if (!entry.mutable) return;
+    this.saving.set(true);
+    this.store.updateServerConfig(entry.key, newValue).subscribe({
+      next: () => {
+        this.toast.success(`"${entry.key}" updated`);
+        entry.value = newValue;
+        this.saving.set(false);
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to update config');
+        this.saving.set(false);
+      }
+    });
+  }
+
+  onFilterChange(): void {
+    this.applyFilter();
+  }
+}

--- a/frontend/src/app/pages/sql-runner/sql-runner.component.html
+++ b/frontend/src/app/pages/sql-runner/sql-runner.component.html
@@ -1,0 +1,114 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">SQL Runner</h1>
+      <p class="page-subtitle">Execute SQL queries against the ApexStore backend</p>
+    </div>
+  </div>
+
+  <div class="runner-layout">
+    <!-- Query editor -->
+    <div class="editor-section">
+      <div class="card">
+        <div class="card-header" style="justify-content:space-between">
+          <div style="display:flex;align-items:center;gap:10px">
+            <hugeicons-icon [icon]="ZapIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+            <span class="card-title">Query</span>
+          </div>
+          <button class="btn btn-secondary btn-sm" (click)="clearResult()" [disabled]="!result() && !error()">
+            <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Clear
+          </button>
+        </div>
+        <div class="card-body">
+          <textarea
+            [(ngModel)]="query"
+            placeholder="SELECT * FROM keys LIMIT 10;"
+            class="query-editor"
+            (keydown.control.enter)="executeQuery()"
+            (keydown.meta.enter)="executeQuery()"
+          ></textarea>
+          <div class="editor-footer">
+            <span class="hint">Ctrl+Enter to execute</span>
+            <button class="btn btn-primary" [disabled]="!query.trim() || loading()" (click)="executeQuery()">
+              @if (loading()) {
+                <span class="spinner"></span>
+              } @else {
+                <hugeicons-icon [icon]="Search01Icon" [size]="15" [strokeWidth]="1.5" />
+              }
+              {{ loading() ? 'Running...' : 'Execute' }}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Error display -->
+      @if (error(); as err) {
+        <div class="error-box">
+          <hugeicons-icon [icon]="CancelCircleIcon" [size]="18" [strokeWidth]="1.5" />
+          <div>
+            <strong>Query Error</strong>
+            <p>{{ err }}</p>
+          </div>
+        </div>
+      }
+
+      <!-- Results table -->
+      @if (result(); as res) {
+        <div class="card" style="margin-top:16px">
+          <div class="card-header" style="justify-content:space-between">
+            <div style="display:flex;align-items:center;gap:10px">
+              <span class="card-title">Results</span>
+              <span class="badge badge-info">{{ res.row_count }} rows</span>
+              <span class="badge badge-warning">{{ res.elapsed_ms }}ms</span>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table class="result-table">
+              <thead>
+                <tr>
+                  @for (col of res.columns; track col) {
+                    <th>{{ col }}</th>
+                  }
+                </tr>
+              </thead>
+              <tbody>
+                @for (row of res.rows; track $index) {
+                  <tr>
+                    @for (col of res.columns; track col) {
+                      <td class="mono">{{ row[col] ?? '—' }}</td>
+                    }
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+          @if (res.rows.length === 0) {
+            <div class="empty-state">Query executed successfully but returned no rows.</div>
+          }
+        </div>
+      }
+    </div>
+
+    <!-- History sidebar -->
+    <aside class="history-section">
+      <div class="card">
+        <div class="card-header" style="justify-content:space-between">
+          <span class="card-title">History</span>
+          <button class="btn btn-secondary btn-sm" (click)="clearHistory()" [disabled]="history().length === 0">
+            <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" />
+          </button>
+        </div>
+        <div class="history-list">
+          @if (history().length === 0) {
+            <div class="empty-state-sm">No queries yet.</div>
+          }
+          @for (q of history(); track $index) {
+            <div class="history-item" (click)="loadFromHistory(q)">
+              <code>{{ q.length > 80 ? q.substring(0, 80) + '...' : q }}</code>
+            </div>
+          }
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>

--- a/frontend/src/app/pages/sql-runner/sql-runner.component.scss
+++ b/frontend/src/app/pages/sql-runner/sql-runner.component.scss
@@ -1,0 +1,199 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.runner-layout {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 16px;
+  align-items: start;
+}
+
+.editor-section {
+  min-width: 0;
+}
+
+.history-section {
+  position: sticky;
+  top: 32px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.query-editor {
+  width: 100%;
+  min-height: 140px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+
+  &:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-dim);
+  }
+
+  &::placeholder {
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+  }
+}
+
+.editor-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.error-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  background: var(--red-dim);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-lg);
+  margin-top: 16px;
+  color: var(--red);
+
+  strong {
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.85rem;
+    font-family: var(--font-mono);
+  }
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+    white-space: nowrap;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.mono {
+  font-family: var(--font-mono);
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.empty-state {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.empty-state-sm {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.history-list {
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.history-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.1s;
+
+  &:hover {
+    background: var(--bg-card-hover);
+  }
+
+  code {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+  }
+}

--- a/frontend/src/app/pages/sql-runner/sql-runner.component.ts
+++ b/frontend/src/app/pages/sql-runner/sql-runner.component.ts
@@ -1,0 +1,87 @@
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe, JsonPipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Search01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  ZapIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface QueryResult {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  row_count: number;
+  elapsed_ms: number;
+}
+
+@Component({
+  selector: 'app-sql-runner',
+  standalone: true,
+  imports: [FormsModule, DatePipe, JsonPipe, HugeiconsIconComponent],
+  templateUrl: './sql-runner.component.html',
+  styleUrl: './sql-runner.component.scss'
+})
+export class SqlRunnerComponent {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Search01Icon = Search01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly ZapIcon = ZapIcon;
+
+  query = '';
+  result = signal<QueryResult | null>(null);
+  error = signal<string | null>(null);
+  loading = signal(false);
+  history = signal<string[]>([]);
+
+  executeQuery(): void {
+    const q = this.query.trim();
+    if (!q) return;
+
+    this.loading.set(true);
+    this.result.set(null);
+    this.error.set(null);
+
+    this.store.executeQuery(q).subscribe({
+      next: (data) => {
+        this.result.set(data);
+        this.addToHistory(q);
+        this.loading.set(false);
+        this.toast.success(`Query returned ${data.row_count} rows in ${data.elapsed_ms}ms`);
+      },
+      error: (e) => {
+        const msg = e?.error?.message ?? e?.message ?? 'Query execution failed';
+        this.error.set(msg);
+        this.loading.set(false);
+      }
+    });
+  }
+
+  private addToHistory(q: string): void {
+    this.history.update(h => [q, ...h.filter(item => item !== q)].slice(0, 20));
+  }
+
+  loadFromHistory(q: string): void {
+    this.query = q;
+    this.executeQuery();
+  }
+
+  clearHistory(): void {
+    this.history.set([]);
+  }
+
+  clearResult(): void {
+    this.result.set(null);
+    this.error.set(null);
+  }
+}

--- a/frontend/src/app/pages/sync-status/sync-status.component.html
+++ b/frontend/src/app/pages/sync-status/sync-status.component.html
@@ -1,0 +1,64 @@
+<div class="sync-status-container">
+  <h1>Sync Status</h1>
+
+  <div class="sync-card">
+    <div class="card-header">
+      <h2>Connection</h2>
+      <button class="btn btn-outline" (click)="disconnect()" [disabled]="syncStatus() === 'disconnected'">
+        Disconnect
+      </button>
+    </div>
+
+    <div class="connection-row">
+      <label for="deviceId">Device ID</label>
+      <div class="input-group">
+        <input
+          id="deviceId"
+          type="text"
+          [(ngModel)]="deviceId"
+          placeholder="Enter device identifier"
+          [disabled]="syncStatus() === 'connected' || syncStatus() === 'connecting'"
+        />
+        <button class="btn btn-primary" (click)="connect()" [disabled]="syncStatus() === 'connected' || syncStatus() === 'connecting' || !deviceId().trim()">
+          Connect
+        </button>
+      </div>
+    </div>
+
+    <div class="status-row">
+      <span class="status-label">Status</span>
+      <span class="status-value" [style.color]="statusColor(syncStatus())">
+        <app-hugeicons-icon [icon]="statusIcon(syncStatus())" size="18" />
+        {{ syncStatus() }}
+      </span>
+    </div>
+
+    <div class="status-row">
+      <span class="status-label">Last Sync</span>
+      <span class="status-value">{{ lastSyncedLabel() }}</span>
+    </div>
+
+    <div class="status-row">
+      <span class="status-label">Pending Changes</span>
+      <span class="status-value">{{ pending() }}</span>
+    </div>
+
+    @if (lastError(); as err) {
+      <div class="error-row">
+        <app-hugeicons-icon [icon]="CancelCircleIcon" size="16" />
+        {{ err }}
+      </div>
+    }
+  </div>
+
+  <div class="sync-card">
+    <div class="card-header">
+      <h2>Activity</h2>
+      <label class="toggle-label">
+        <input type="checkbox" [(ngModel)]="autoRefresh" />
+        Auto-refresh
+      </label>
+    </div>
+    <p class="hint">Connected devices will receive real-time changes pushed from the server or other clients.</p>
+  </div>
+</div>

--- a/frontend/src/app/pages/sync-status/sync-status.component.scss
+++ b/frontend/src/app/pages/sync-status/sync-status.component.scss
@@ -1,0 +1,105 @@
+.sync-status-container {
+  padding: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+
+  h1 {
+    margin-bottom: 24px;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+}
+
+.sync-card {
+  background: var(--surface, #1e1e2e);
+  border: 1px solid var(--border, #2e2e3e);
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 16px;
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+
+    h2 {
+      margin: 0;
+      font-size: 1.1rem;
+      font-weight: 500;
+    }
+  }
+}
+
+.connection-row {
+  margin-bottom: 16px;
+
+  label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 0.85rem;
+    color: var(--text-muted, #a0a0b0);
+  }
+
+  .input-group {
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border, #2e2e3e);
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  .status-label {
+    font-size: 0.9rem;
+    color: var(--text-muted, #a0a0b0);
+  }
+
+  .status-value {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+}
+
+.error-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  margin-top: 12px;
+  background: rgba(255, 70, 70, 0.1);
+  border: 1px solid rgba(255, 70, 70, 0.3);
+  border-radius: 8px;
+  color: var(--color-error, #ff4646);
+  font-size: 0.85rem;
+}
+
+.toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.hint {
+  color: var(--text-muted, #a0a0b0);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/app/pages/sync-status/sync-status.component.ts
+++ b/frontend/src/app/pages/sync-status/sync-status.component.ts
@@ -1,0 +1,106 @@
+import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  Time05Icon,
+  DataIcon,
+  ArrowRight01Icon,
+} from '@hugeicons/core-free-icons';
+import { SyncService, SyncStatus } from '../../services/sync.service';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-sync-status',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './sync-status.component.html',
+  styleUrl: './sync-status.component.scss',
+})
+export class SyncStatusComponent implements OnInit, OnDestroy {
+  private sync = inject(SyncService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly Time05Icon = Time05Icon;
+  readonly DataIcon = DataIcon;
+  readonly ArrowRight01Icon = ArrowRight01Icon;
+
+  deviceId = signal('');
+  syncStatus = this.sync.status;
+  lastSync = this.sync.lastSyncTimestamp;
+  pending = this.sync.pendingChanges;
+  lastError = this.sync.lastError;
+  autoRefresh = signal(false);
+  lastSyncedLabel = signal<string>('Never');
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  statusIcon(status: SyncStatus): typeof RefreshIcon {
+    switch (status) {
+      case 'connected': return CheckmarkCircle01Icon;
+      case 'connecting': return Time05Icon;
+      case 'error': return CancelCircleIcon;
+      default: return CancelCircleIcon;
+    }
+  }
+
+  statusColor(status: SyncStatus): string {
+    switch (status) {
+      case 'connected': return 'var(--color-success)';
+      case 'connecting': return 'var(--color-warning)';
+      case 'error': return 'var(--color-error)';
+      default: return 'var(--color-muted)';
+    }
+  }
+
+  ngOnInit(): void {
+    this.sync.lastSyncTimestamp.subscribe(ts => {
+      if (ts) {
+        this.lastSyncedLabel.set(new Date(ts).toLocaleString());
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.stopAutoRefresh();
+  }
+
+  connect(): void {
+    const id = this.deviceId().trim();
+    if (!id) {
+      this.toast.error('Please enter a device ID');
+      return;
+    }
+    this.sync.connect(id);
+    this.toast.info(`Connecting as "${id}"...`);
+    if (this.autoRefresh()) {
+      this.startAutoRefresh();
+    }
+  }
+
+  disconnect(): void {
+    this.sync.disconnect();
+    this.toast.info('Disconnected');
+    this.stopAutoRefresh();
+  }
+
+  private startAutoRefresh(): void {
+    this.stopAutoRefresh();
+    this.refreshTimer = setInterval(() => {
+      // Trigger a status refresh by re-checking signals
+      this.lastSyncedLabel.update(l => l);
+    }, 5000);
+  }
+
+  private stopAutoRefresh(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+}

--- a/frontend/src/app/pages/tags/tags.component.html
+++ b/frontend/src/app/pages/tags/tags.component.html
@@ -1,0 +1,76 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Tags</h1>
+      <p class="page-subtitle">Browse notes by tag</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadTags()" [disabled]="loadingTags()">
+      @if (loadingTags()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <div class="tags-layout">
+    <!-- Tags list -->
+    <aside class="tags-sidebar">
+      <div class="sidebar-label">All Tags</div>
+      @if (loadingTags() && tags().length === 0) {
+        <div class="loading-inline">
+          <span class="spinner" style="width:20px;height:20px;border-width:2px"></span>
+        </div>
+      } @else if (tags().length === 0) {
+        <div class="empty-state">No tags found</div>
+      } @else {
+        <div class="tags-list">
+          @for (tag of tags(); track tag) {
+            <div
+              class="tag-item"
+              [class.active]="selectedTag() === tag"
+              (click)="selectTag(tag)"
+            >
+              <hugeicons-icon [icon]="Tag01Icon" [size]="14" [strokeWidth]="1.5" />
+              <span>{{ tag }}</span>
+            </div>
+          }
+        </div>
+      }
+    </aside>
+
+    <!-- Notes for selected tag -->
+    <main class="tag-notes">
+      @if (!selectedTag()) {
+        <div class="empty-state">Select a tag to see its notes</div>
+      } @else if (loadingNotes()) {
+        <div class="loading-state">
+          <span class="spinner" style="width:28px;height:28px;border-width:3px"></span>
+          <p>Loading notes...</p>
+        </div>
+      } @else if (tagNotes().length === 0) {
+        <div class="empty-state">No notes with tag "{{ selectedTag() }}"</div>
+      } @else {
+        <div class="notes-header">
+          <h2>Notes tagged "{{ selectedTag() }}"</h2>
+          <span class="badge badge-info">{{ tagNotes().length }} note(s)</span>
+        </div>
+        <div class="notes-list">
+          @for (note of tagNotes(); track note.path) {
+            <div class="note-card">
+              <div class="note-card-header">
+                <hugeicons-icon [icon]="Tag01Icon" [size]="14" [strokeWidth]="1.5" />
+                <span class="note-card-path">{{ note.path }}</span>
+              </div>
+              @if (note.updated_at) {
+                <p class="note-card-meta">Updated {{ note.updated_at | date:'medium' }}</p>
+              }
+              <p class="note-card-preview">{{ note.content | slice:0:200 }}{{ note.content.length > 200 ? '...' : '' }}</p>
+            </div>
+          }
+        </div>
+      }
+    </main>
+  </div>
+</div>

--- a/frontend/src/app/pages/tags/tags.component.scss
+++ b/frontend/src/app/pages/tags/tags.component.scss
@@ -1,0 +1,170 @@
+.page {
+  padding: 32px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.tags-layout {
+  display: flex;
+  flex: 1;
+  gap: 0;
+  overflow: hidden;
+}
+
+.tags-sidebar {
+  width: 220px;
+  min-width: 220px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 14px 16px 8px;
+}
+
+.tags-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px 8px;
+}
+
+.tag-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+
+  &:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+  }
+
+  &.active {
+    background: var(--accent-dim);
+    color: var(--accent);
+  }
+}
+
+.tag-notes {
+  flex: 1;
+  padding-left: 24px;
+  overflow-y: auto;
+}
+
+.empty-state {
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.loading-state,
+.loading-inline {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  gap: 12px;
+  color: var(--text-muted);
+}
+
+.loading-inline {
+  padding: 24px;
+}
+
+.notes-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+
+  h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+  }
+}
+
+.notes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.note-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: border-color 0.15s;
+
+  &:hover {
+    border-color: var(--border-light);
+  }
+}
+
+.note-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.note-card-path {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.note-card-meta {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.note-card-preview {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0;
+  word-break: break-word;
+}

--- a/frontend/src/app/pages/tags/tags.component.ts
+++ b/frontend/src/app/pages/tags/tags.component.ts
@@ -1,0 +1,50 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule, DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Tag01Icon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService, Note } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+@Component({
+  selector: 'app-tags',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './tags.component.html',
+  styleUrl: './tags.component.scss'
+})
+export class TagsComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Tag01Icon   = Tag01Icon;
+
+  tags         = signal<string[]>([]);
+  selectedTag  = signal<string | null>(null);
+  tagNotes     = signal<Note[]>([]);
+  loadingTags  = signal(false);
+  loadingNotes = signal(false);
+
+  ngOnInit(): void { this.loadTags(); }
+
+  loadTags(): void {
+    this.loadingTags.set(true);
+    this.store.getTags().subscribe({
+      next: (data) => { this.tags.set(data); this.loadingTags.set(false); },
+      error: (e) => { this.toast.error(e?.error?.message ?? 'Failed to load tags'); this.loadingTags.set(false); }
+    });
+  }
+
+  selectTag(tag: string): void {
+    this.selectedTag.set(tag);
+    this.loadingNotes.set(true);
+    this.tagNotes.set([]);
+    this.store.getTagNotes(tag).subscribe({
+      next: (notes) => { this.tagNotes.set(notes); this.loadingNotes.set(false); },
+      error: (e) => { this.toast.error(e?.error?.message ?? 'Failed to load notes for tag'); this.loadingNotes.set(false); }
+    });
+  }
+}

--- a/frontend/src/app/pages/telemetry/telemetry.component.html
+++ b/frontend/src/app/pages/telemetry/telemetry.component.html
@@ -1,0 +1,105 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Telemetry</h1>
+      <p class="page-subtitle">Log levels and telemetry configuration</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadTelemetry()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Telemetry Config -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Settings01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Telemetry Configuration</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group">
+          <label>Sampling Rate</label>
+          <input type="number" [(ngModel)]="config().sampling_rate" min="0" max="1" step="0.1" />
+        </div>
+        <div class="input-group">
+          <label>Export Interval (sec)</label>
+          <input type="number" [(ngModel)]="config().export_interval_sec" min="10" max="3600" />
+        </div>
+        <div class="input-group">
+          <label>Tracing</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="config().tracing_enabled" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="input-group">
+          <label>Metrics</label>
+          <label class="toggle">
+            <input type="checkbox" [(ngModel)]="config().metrics_enabled" />
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>OTLP Endpoint (optional)</label>
+          <input [(ngModel)]="config().otlp_endpoint" placeholder="http://otel-collector:4318" />
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="saving()" (click)="saveConfig()">
+        @if (saving()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="CheckmarkCircle01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Save Configuration
+      </button>
+    </div>
+  </div>
+
+  <!-- Log Levels -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">Log Levels</span>
+        <span class="badge badge-info">{{ logLevels().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && logLevels().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="log-table">
+          <thead>
+            <tr><th>Module</th><th>Level</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (l of logLevels(); track l.module) {
+              <tr>
+                <td class="mono">{{ l.module }}</td>
+                <td>
+                  <span class="badge" [class.badge-success]="l.level === 'info'" [class.badge-warning]="l.level === 'warn'" [class.badge-danger]="l.level === 'error'" [class.badge-info]="l.level === 'debug' || l.level === 'trace'">
+                    {{ l.level }}
+                  </span>
+                </td>
+                <td>
+                  <div class="level-selector">
+                    @for (opt of levelOptions; track opt) {
+                      <button class="btn btn-sm" [class.btn-primary]="l.level === opt" [class.btn-secondary]="l.level !== opt" (click)="updateLogLevel(l.module, opt)">
+                        {{ opt }}
+                      </button>
+                    }
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/telemetry/telemetry.component.scss
+++ b/frontend/src/app/pages/telemetry/telemetry.component.scss
@@ -1,0 +1,136 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+
+  input { display: none; }
+
+  .toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: var(--border);
+    border-radius: 24px;
+    transition: 0.2s;
+
+    &::before {
+      content: '';
+      position: absolute;
+      width: 18px;
+      height: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: white;
+      border-radius: 50%;
+      transition: 0.2s;
+    }
+  }
+
+  input:checked + .toggle-slider {
+    background: var(--accent);
+
+    &::before { transform: translateX(20px); }
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.level-selector {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}

--- a/frontend/src/app/pages/telemetry/telemetry.component.ts
+++ b/frontend/src/app/pages/telemetry/telemetry.component.ts
@@ -1,0 +1,99 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Settings01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface LogLevel {
+  module: string;
+  level: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'off';
+}
+
+interface TelemetryConfig {
+  sampling_rate: number;
+  export_interval_sec: number;
+  tracing_enabled: boolean;
+  metrics_enabled: boolean;
+  otlp_endpoint?: string;
+}
+
+@Component({
+  selector: 'app-telemetry',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './telemetry.component.html',
+  styleUrl: './telemetry.component.scss'
+})
+export class TelemetryComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Settings01Icon = Settings01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+
+  config = signal<TelemetryConfig>({
+    sampling_rate: 1.0,
+    export_interval_sec: 60,
+    tracing_enabled: true,
+    metrics_enabled: true,
+    otlp_endpoint: ''
+  });
+
+  logLevels = signal<LogLevel[]>([]);
+  loading = signal(false);
+  saving = signal(false);
+
+  levelOptions = ['trace', 'debug', 'info', 'warn', 'error', 'off'];
+
+  ngOnInit(): void { this.loadTelemetry(); }
+
+  loadTelemetry(): void {
+    this.loading.set(true);
+    this.store.getTelemetryConfig().subscribe({
+      next: (data) => {
+        this.config.set(data.config);
+        this.logLevels.set(data.log_levels);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load telemetry configuration');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  saveConfig(): void {
+    this.saving.set(true);
+    this.store.updateTelemetryConfig(this.config()).subscribe({
+      next: () => {
+        this.toast.success('Telemetry configuration saved');
+        this.saving.set(false);
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to save telemetry config');
+        this.saving.set(false);
+      }
+    });
+  }
+
+  updateLogLevel(module: string, level: string): void {
+    this.store.setLogLevel(module, level).subscribe({
+      next: () => {
+        this.toast.success(`Log level for "${module}" set to ${level}`);
+        this.loadTelemetry();
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to update log level')
+    });
+  }
+}

--- a/frontend/src/app/pages/time-travel/time-travel.component.html
+++ b/frontend/src/app/pages/time-travel/time-travel.component.html
@@ -1,0 +1,111 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Time Travel</h1>
+      <p class="page-subtitle">Snapshot browser - create and restore point-in-time snapshots</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadSnapshots()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Create snapshot -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Share08Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Create Snapshot</span>
+    </div>
+    <div class="card-body">
+      <div class="form-row">
+        <div class="input-group" style="flex:1">
+          <label>Snapshot name (optional)</label>
+          <input [(ngModel)]="snapshotName" placeholder="Leave empty for auto-name" (keydown.enter)="createSnapshot()" />
+        </div>
+        <button class="btn btn-primary" style="align-self:flex-end" [disabled]="creating()" (click)="createSnapshot()">
+          @if (creating()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+          }
+          {{ creating() ? 'Creating...' : 'Create Snapshot' }}
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Snapshots list -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">Snapshots</span>
+        <span class="badge badge-info">{{ snapshots().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && snapshots().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (snapshots().length === 0) {
+      <div class="empty-state">No snapshots yet. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="snapshots-table">
+          <thead>
+            <tr><th>Name</th><th>Notes</th><th>Created</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (s of snapshots(); track s.id) {
+              <tr>
+                <td class="name-cell">{{ s.name }}</td>
+                <td>{{ s.note_count }}</td>
+                <td class="time-cell">{{ nsToDate(s.created_at) | date:'dd/MM/yy HH:mm' }}</td>
+                <td>
+                  <div class="action-btns">
+                    <button class="btn btn-secondary btn-sm" (click)="viewSnapshot(s)">
+                      <hugeicons-icon [icon]="ArrowRight01Icon" [size]="14" [strokeWidth]="1.5" /> Browse
+                    </button>
+                    <button class="btn btn-success btn-sm" (click)="restoreSnapshot(s.id, s.name)">
+                      <hugeicons-icon [icon]="ArrowRight01Icon" [size]="14" [strokeWidth]="1.5" /> Restore
+                    </button>
+                    <button class="btn btn-danger btn-sm" (click)="deleteSnapshot(s.id, s.name)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+
+  <!-- Snapshot notes -->
+  @if (notes().length > 0) {
+    <div class="card" style="margin-top:24px">
+      <div class="card-header" style="justify-content:space-between">
+        <div style="display:flex;align-items:center;gap:10px">
+          <span class="card-title">Snapshot Notes</span>
+          <span class="badge badge-info">{{ notes().length }}</span>
+        </div>
+        <button class="btn btn-secondary btn-sm" (click)="closeNotes()">
+          <hugeicons-icon [icon]="CancelCircleIcon" [size]="14" [strokeWidth]="1.5" /> Close
+        </button>
+      </div>
+      <div class="card-body">
+        <div class="notes-list">
+          @for (note of notes(); track note.path) {
+            <div class="note-item">
+              <strong>{{ note.path }}</strong>
+              <p>{{ note.content?.substring(0, 200) }}{{ note.content?.length > 200 ? '...' : '' }}</p>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/time-travel/time-travel.component.scss
+++ b/frontend/src/app/pages/time-travel/time-travel.component.scss
@@ -1,0 +1,140 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.snapshots-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}
+
+.notes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.note-item {
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+
+  strong {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    margin-bottom: 4px;
+    color: var(--accent);
+  }
+
+  p {
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+}

--- a/frontend/src/app/pages/time-travel/time-travel.component.ts
+++ b/frontend/src/app/pages/time-travel/time-travel.component.ts
@@ -1,0 +1,125 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  Add01Icon,
+  Delete01Icon,
+  ArrowRight01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService, Note } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface Snapshot {
+  id: string;
+  name: string;
+  created_at: number;
+  note_count: number;
+}
+
+@Component({
+  selector: 'app-time-travel',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './time-travel.component.html',
+  styleUrl: './time-travel.component.scss'
+})
+export class TimeTravelComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly ArrowRight01Icon = ArrowRight01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+
+  snapshots = signal<Snapshot[]>([]);
+  notes = signal<Note[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+  viewingNotes = signal(false);
+  snapshotName = '';
+
+  ngOnInit(): void { this.loadSnapshots(); }
+
+  loadSnapshots(): void {
+    this.loading.set(true);
+    this.store.listSnapshots().subscribe({
+      next: (data) => {
+        this.snapshots.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load snapshots');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createSnapshot(): void {
+    const name = this.snapshotName.trim() || `snapshot-${Date.now()}`;
+    this.creating.set(true);
+    this.store.createSnapshot(name).subscribe({
+      next: () => {
+        this.toast.success(`Snapshot "${name}" created!`);
+        this.snapshotName = '';
+        this.creating.set(false);
+        this.loadSnapshots();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Snapshot creation failed');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  viewSnapshot(snapshot: Snapshot): void {
+    this.viewingNotes.set(true);
+    this.store.getSnapshotNotes(snapshot.id).subscribe({
+      next: (data) => {
+        this.notes.set(data);
+        this.viewingNotes.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load snapshot notes');
+        this.viewingNotes.set(false);
+      }
+    });
+  }
+
+  restoreSnapshot(id: string, name: string): void {
+    if (!confirm(`Restore snapshot "${name}"? This will overwrite current data.`)) return;
+    this.store.restoreSnapshot(id).subscribe({
+      next: () => {
+        this.toast.success(`Snapshot "${name}" restored!`);
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Restore failed')
+    });
+  }
+
+  deleteSnapshot(id: string, name: string): void {
+    if (!confirm(`Delete snapshot "${name}"?`)) return;
+    this.store.deleteSnapshot(id).subscribe({
+      next: () => {
+        this.toast.success(`Snapshot "${name}" deleted`);
+        this.snapshots.update(list => list.filter(s => s.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Delete failed')
+    });
+  }
+
+  closeNotes(): void {
+    this.notes.set([]);
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/vector-search/vector-search.component.html
+++ b/frontend/src/app/pages/vector-search/vector-search.component.html
@@ -1,0 +1,155 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Vector Search</h1>
+      <p class="page-subtitle">Vector index management and semantic search</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadIndexes()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <div class="grid-2col">
+    <!-- Create Index -->
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Add01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Create Index</span>
+      </div>
+      <div class="card-body">
+        <div class="form-grid">
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Index Name</label>
+            <input [(ngModel)]="newIndexName" placeholder="my_vectors" />
+          </div>
+          <div class="input-group">
+            <label>Dimensions</label>
+            <input type="number" [(ngModel)]="newIndexDim" min="1" max="4096" />
+          </div>
+          <div class="input-group">
+            <label>Metric</label>
+            <select [(ngModel)]="newIndexMetric">
+              @for (m of metrics; track m.value) {
+                <option [value]="m.value">{{ m.label }}</option>
+              }
+            </select>
+          </div>
+        </div>
+        <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newIndexName.trim() || creating()" (click)="createIndex()">
+          @if (creating()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+          }
+          Create Index
+        </button>
+      </div>
+    </div>
+
+    <!-- Search Panel -->
+    <div class="card">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Search01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Semantic Search</span>
+      </div>
+      <div class="card-body">
+        <div class="form-grid">
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Index</label>
+            <select [(ngModel)]="selectedIndex">
+              @for (idx of indexes(); track idx.name) {
+                <option [value]="idx.name">{{ idx.name }}</option>
+              }
+            </select>
+          </div>
+          <div class="input-group" style="grid-column:1/-1">
+            <label>Query (text or vector)</label>
+            <input [(ngModel)]="searchQuery" placeholder="Search query..." (keydown.enter)="executeSearch()" />
+          </div>
+        </div>
+        <button class="btn btn-success" style="margin-top:14px" [disabled]="!searchQuery.trim() || !selectedIndex || searching()" (click)="executeSearch()">
+          @if (searching()) {
+            <span class="spinner"></span>
+          } @else {
+            <hugeicons-icon [icon]="Search01Icon" [size]="15" [strokeWidth]="1.5" />
+          }
+          Search
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Indexes List -->
+  <div class="card" style="margin-top:24px">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="DatabaseIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Vector Indexes</span>
+        <span class="badge badge-info">{{ indexes().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && indexes().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (indexes().length === 0) {
+      <div class="empty-state">No vector indexes. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="indexes-table">
+          <thead>
+            <tr><th>Name</th><th>Dimensions</th><th>Metric</th><th>Size</th><th>Status</th><th>Created</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (idx of indexes(); track idx.name) {
+              <tr>
+                <td class="mono name-cell">{{ idx.name }}</td>
+                <td class="mono">{{ idx.dimension }}</td>
+                <td>{{ idx.metric }}</td>
+                <td class="mono">{{ idx.size }} vectors</td>
+                <td><span class="badge" [ngClass]="indexStatusClass(idx.status)">{{ idx.status }}</span></td>
+                <td class="time-cell">{{ nsToDate(idx.created_at) | date:'dd/MM/yy HH:mm' }}</td>
+                <td>
+                  <button class="btn btn-danger btn-sm" (click)="deleteIndex(idx.name)">
+                    <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+
+  <!-- Search Results -->
+  @if (searchResults().length > 0) {
+    <div class="card" style="margin-top:24px">
+      <div class="card-header">
+        <hugeicons-icon [icon]="Search01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Search Results</span>
+        <span class="badge badge-info">{{ searchResults().length }}</span>
+      </div>
+      <div class="table-wrapper">
+        <table class="results-table">
+          <thead>
+            <tr><th>#</th><th>Key</th><th>Score</th></tr>
+          </thead>
+          <tbody>
+            @for (r of searchResults(); track $index) {
+              <tr>
+                <td>{{ $index + 1 }}</td>
+                <td class="mono">{{ r.key }}</td>
+                <td class="mono">{{ r.score | number:'1.4f' }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/vector-search/vector-search.component.scss
+++ b/frontend/src/app/pages/vector-search/vector-search.component.scss
@@ -1,0 +1,118 @@
+.page {
+  padding: 32px;
+  max-width: 1200px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.indexes-table, .results-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.name-cell {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}

--- a/frontend/src/app/pages/vector-search/vector-search.component.ts
+++ b/frontend/src/app/pages/vector-search/vector-search.component.ts
@@ -1,0 +1,145 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Search01Icon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  DatabaseIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface VectorIndex {
+  name: string;
+  dimension: number;
+  metric: 'cosine' | 'euclidean' | 'dot';
+  size: number;
+  status: 'active' | 'building' | 'failed';
+  created_at: number;
+}
+
+interface SearchResult {
+  key: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+@Component({
+  selector: 'app-vector-search',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './vector-search.component.html',
+  styleUrl: './vector-search.component.scss'
+})
+export class VectorSearchComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Search01Icon = Search01Icon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly DatabaseIcon = DatabaseIcon;
+
+  indexes = signal<VectorIndex[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+
+  searchQuery = '';
+  searchResults = signal<SearchResult[]>([]);
+  searching = signal(false);
+  selectedIndex = '';
+
+  newIndexName = '';
+  newIndexDim = 128;
+  newIndexMetric: 'cosine' | 'euclidean' | 'dot' = 'cosine';
+
+  metrics: Array<{ value: string; label: string }> = [
+    { value: 'cosine', label: 'Cosine' },
+    { value: 'euclidean', label: 'Euclidean' },
+    { value: 'dot', label: 'Dot Product' },
+  ];
+
+  ngOnInit(): void { this.loadIndexes(); }
+
+  loadIndexes(): void {
+    this.loading.set(true);
+    this.store.listVectorIndexes().subscribe({
+      next: (data) => {
+        this.indexes.set(data);
+        if (data.length > 0 && !this.selectedIndex) {
+          this.selectedIndex = data[0].name;
+        }
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load vector indexes');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createIndex(): void {
+    const name = this.newIndexName.trim();
+    if (!name) return;
+    this.creating.set(true);
+    this.store.createVectorIndex(name, this.newIndexDim, this.newIndexMetric).subscribe({
+      next: () => {
+        this.toast.success(`Index "${name}" created!`);
+        this.newIndexName = '';
+        this.creating.set(false);
+        this.loadIndexes();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create index');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  deleteIndex(name: string): void {
+    if (!confirm(`Delete vector index "${name}"? All vectors will be lost.`)) return;
+    this.store.deleteVectorIndex(name).subscribe({
+      next: () => {
+        this.toast.success(`Index "${name}" deleted`);
+        this.indexes.update(list => list.filter(i => i.name !== name));
+        if (this.selectedIndex === name) this.selectedIndex = '';
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete index')
+    });
+  }
+
+  executeSearch(): void {
+    if (!this.searchQuery.trim() || !this.selectedIndex) return;
+    this.searching.set(true);
+    this.store.vectorSearch(this.selectedIndex, this.searchQuery.trim()).subscribe({
+      next: (results) => {
+        this.searchResults.set(results);
+        this.searching.set(false);
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Search failed');
+        this.searching.set(false);
+      }
+    });
+  }
+
+  indexStatusClass(status: string): string {
+    switch (status) {
+      case 'active': return 'badge-success';
+      case 'building': return 'badge-warning';
+      default: return 'badge-danger';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/wasm-plugins/wasm-plugins.component.html
+++ b/frontend/src/app/pages/wasm-plugins/wasm-plugins.component.html
@@ -1,0 +1,92 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">WASM Plugins</h1>
+      <p class="page-subtitle">WebAssembly plugin manager</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadPlugins()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Upload Plugin -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <hugeicons-icon [icon]="Upload01Icon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+      <span class="card-title">Upload Plugin</span>
+    </div>
+    <div class="card-body">
+      <div class="upload-area">
+        <input type="file" (change)="onFileSelected($event)" [disabled]="uploading()" accept=".wasm" id="wasm-file" />
+        <label for="wasm-file" class="upload-label">
+          @if (uploading()) {
+            <span class="spinner" style="width:24px;height:24px;border-width:3px"></span>
+            <span>Uploading...</span>
+          } @else {
+            <hugeicons-icon [icon]="Upload01Icon" [size]="24" [strokeWidth]="1.5" />
+            <span>Click to select a .wasm file</span>
+          }
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <!-- Plugins List -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <hugeicons-icon [icon]="CpuIcon" [size]="17" [strokeWidth]="1.5" color="var(--accent)" />
+        <span class="card-title">Plugins</span>
+        <span class="badge badge-info">{{ plugins().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && plugins().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (plugins().length === 0) {
+      <div class="empty-state">No WASM plugins. Upload one above.</div>
+    } @else {
+      <div class="plugin-grid">
+        @for (p of plugins(); track p.id) {
+          <div class="plugin-card">
+            <div class="plugin-header">
+              <hugeicons-icon [icon]="CpuIcon" [size]="20" [strokeWidth]="1.5" color="var(--accent)" />
+              <div class="plugin-info">
+                <span class="plugin-name">{{ p.name }}</span>
+                <span class="plugin-version">v{{ p.version }}</span>
+              </div>
+              <span class="badge" [ngClass]="statusClass(p.status)">{{ p.status }}</span>
+            </div>
+            <div class="plugin-meta">
+              <span class="badge" [ngClass]="typeClass(p.type)">{{ p.type }}</span>
+              <span class="plugin-size">{{ p.size_kb }} KB</span>
+            </div>
+            <p class="plugin-desc">{{ p.description }}</p>
+            <div class="plugin-footer">
+              <span class="time-cell">Uploaded {{ nsToDate(p.created_at) | date:'dd/MM/yy' }}</span>
+              <div class="action-btns">
+                <button class="btn btn-sm" [class.btn-success]="p.status === 'inactive'" [class.btn-warning]="p.status === 'active'" (click)="togglePlugin(p.id)" [disabled]="toggling() === p.id">
+                  @if (toggling() === p.id) {
+                    <span class="spinner" style="width:14px;height:14px;border-width:2px"></span>
+                  } @else if (p.status === 'active') {
+                    <hugeicons-icon [icon]="PauseIcon" [size]="14" [strokeWidth]="1.5" /> Deactivate
+                  } @else {
+                    <hugeicons-icon [icon]="PlayIcon" [size]="14" [strokeWidth]="1.5" /> Activate
+                  }
+                </button>
+                <button class="btn btn-danger btn-sm" (click)="deletePlugin(p.id)">
+                  <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                </button>
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/wasm-plugins/wasm-plugins.component.scss
+++ b/frontend/src/app/pages/wasm-plugins/wasm-plugins.component.scss
@@ -1,0 +1,164 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.upload-area {
+  input[type="file"] { display: none; }
+
+  .upload-label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 40px;
+    border: 2px dashed var(--border);
+    border-radius: 12px;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    transition: all 0.15s;
+
+    &:hover {
+      border-color: var(--accent);
+      color: var(--accent);
+      background: var(--accent-dim);
+    }
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.plugin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  padding: 18px;
+}
+
+.plugin-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.plugin-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.plugin-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.plugin-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.plugin-version {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.plugin-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.plugin-size {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.plugin-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.plugin-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}

--- a/frontend/src/app/pages/wasm-plugins/wasm-plugins.component.ts
+++ b/frontend/src/app/pages/wasm-plugins/wasm-plugins.component.ts
@@ -1,0 +1,139 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Upload01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  CpuIcon,
+  PlayIcon,
+  PauseIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface WasmPlugin {
+  id: string;
+  name: string;
+  version: string;
+  type: 'filter' | 'transform' | 'auth' | 'custom';
+  status: 'active' | 'inactive' | 'error';
+  size_kb: number;
+  description: string;
+  created_at: number;
+}
+
+@Component({
+  selector: 'app-wasm-plugins',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './wasm-plugins.component.html',
+  styleUrl: './wasm-plugins.component.scss'
+})
+export class WasmPluginsComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Upload01Icon = Upload01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly CpuIcon = CpuIcon;
+  readonly PlayIcon = PlayIcon;
+  readonly PauseIcon = PauseIcon;
+
+  plugins = signal<WasmPlugin[]>([]);
+  loading = signal(false);
+  uploading = signal(false);
+  toggling = signal<string | null>(null);
+
+  ngOnInit(): void { this.loadPlugins(); }
+
+  loadPlugins(): void {
+    this.loading.set(true);
+    this.store.listWasmPlugins().subscribe({
+      next: (data) => {
+        this.plugins.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load WASM plugins');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files?.length) return;
+    const file = input.files[0];
+    if (!file.name.endsWith('.wasm')) {
+      this.toast.error('Please select a .wasm file');
+      return;
+    }
+    this.uploading.set(true);
+    this.store.uploadWasmPlugin(file).subscribe({
+      next: () => {
+        this.toast.success(`Plugin "${file.name}" uploaded`);
+        this.uploading.set(false);
+        this.loadPlugins();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Upload failed');
+        this.uploading.set(false);
+      }
+    });
+    input.value = '';
+  }
+
+  togglePlugin(id: string): void {
+    this.toggling.set(id);
+    this.store.toggleWasmPlugin(id).subscribe({
+      next: () => {
+        this.toast.success('Plugin toggled');
+        this.toggling.set(null);
+        this.loadPlugins();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to toggle plugin');
+        this.toggling.set(null);
+      }
+    });
+  }
+
+  deletePlugin(id: string): void {
+    if (!confirm('Delete this WASM plugin?')) return;
+    this.store.deleteWasmPlugin(id).subscribe({
+      next: () => {
+        this.toast.success('Plugin deleted');
+        this.plugins.update(list => list.filter(p => p.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete plugin')
+    });
+  }
+
+  typeClass(type: string): string {
+    switch (type) {
+      case 'filter': return 'badge-info';
+      case 'transform': return 'badge-warning';
+      case 'auth': return 'badge-primary';
+      default: return 'badge-default';
+    }
+  }
+
+  statusClass(status: string): string {
+    switch (status) {
+      case 'active': return 'badge-success';
+      case 'inactive': return 'badge-warning';
+      default: return 'badge-danger';
+    }
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/pages/webhooks/webhooks.component.html
+++ b/frontend/src/app/pages/webhooks/webhooks.component.html
@@ -1,0 +1,121 @@
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Webhooks</h1>
+      <p class="page-subtitle">Manage webhook endpoints for event notifications</p>
+    </div>
+    <button class="btn btn-secondary" (click)="loadWebhooks()" [disabled]="loading()">
+      @if (loading()) {
+        <span class="spinner"></span>
+      } @else {
+        <hugeicons-icon [icon]="RefreshIcon" [size]="16" [strokeWidth]="1.5" />
+      }
+      Refresh
+    </button>
+  </div>
+
+  <!-- Create webhook -->
+  <div class="card" style="margin-bottom:24px">
+    <div class="card-header">
+      <span class="op-badge">POST</span>
+      <span class="card-title">Create Webhook</span>
+    </div>
+    <div class="card-body">
+      <div class="form-grid">
+        <div class="input-group" style="grid-column:1/-1">
+          <label>URL</label>
+          <input [(ngModel)]="newUrl" placeholder="https://hooks.example.com/events" />
+        </div>
+        <div class="input-group" style="grid-column:1/-1">
+          <label>Events (comma-separated)</label>
+          <div class="event-chips">
+            @for (evt of allEventOptions; track evt) {
+              <label class="event-chip" [class.selected]="isEventSelected(evt)">
+                <input type="checkbox" [checked]="isEventSelected(evt)" (change)="toggleEvent(evt)" />
+                {{ evt }}
+              </label>
+            }
+          </div>
+        </div>
+      </div>
+      <button class="btn btn-primary" style="margin-top:14px" [disabled]="!newUrl.trim() || creating()" (click)="createWebhook()">
+        @if (creating()) {
+          <span class="spinner"></span>
+        } @else {
+          <hugeicons-icon [icon]="Add01Icon" [size]="15" [strokeWidth]="1.5" />
+        }
+        Create Webhook
+      </button>
+    </div>
+  </div>
+
+  <!-- Webhooks list -->
+  <div class="card">
+    <div class="card-header" style="justify-content:space-between">
+      <div style="display:flex;align-items:center;gap:10px">
+        <span class="card-title">Webhooks</span>
+        <span class="badge badge-info">{{ webhooks().length }}</span>
+      </div>
+    </div>
+
+    @if (loading() && webhooks().length === 0) {
+      <div class="loading-state"><span class="spinner" style="width:28px;height:28px;border-width:3px"></span></div>
+    } @else if (webhooks().length === 0) {
+      <div class="empty-state">No webhooks configured. Create one above.</div>
+    } @else {
+      <div class="table-wrapper">
+        <table class="webhooks-table">
+          <thead>
+            <tr><th>URL</th><th>Events</th><th>Status</th><th>Last Trigger</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            @for (w of webhooks(); track w.id) {
+              <tr>
+                <td class="mono url-cell">{{ w.url }}</td>
+                <td>
+                  <div class="event-badges">
+                    @for (evt of w.events; track evt) {
+                      <span class="badge badge-info">{{ evt }}</span>
+                    }
+                  </div>
+                </td>
+                <td>
+                  @if (w.active) {
+                    <span class="badge badge-success">Active</span>
+                  } @else {
+                    <span class="badge badge-danger">Inactive</span>
+                  }
+                </td>
+                <td class="time-cell">
+                  @if (w.last_triggered_at) {
+                    {{ nsToDate(w.last_triggered_at) | date:'dd/MM HH:mm' }}
+                    @if (w.last_status) {
+                      <br /><span class="badge" [class.badge-success]="w.last_status === 'success'" [class.badge-danger]="w.last_status !== 'success'">{{ w.last_status }}</span>
+                    }
+                  } @else {
+                    <span style="color:var(--text-muted)">Never</span>
+                  }
+                </td>
+                <td>
+                  <div class="action-btns">
+                    <button class="btn btn-secondary btn-sm" (click)="testWebhook(w.id)" [disabled]="testing() === w.id">
+                      @if (testing() === w.id) {
+                        <span class="spinner"></span>
+                      } @else {
+                        <hugeicons-icon [icon]="ZapIcon" [size]="14" [strokeWidth]="1.5" />
+                      }
+                      Test
+                    </button>
+                    <button class="btn btn-danger btn-sm" (click)="deleteWebhook(w.id)">
+                      <hugeicons-icon [icon]="Delete01Icon" [size]="14" [strokeWidth]="1.5" /> Delete
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </div>
+</div>

--- a/frontend/src/app/pages/webhooks/webhooks.component.scss
+++ b/frontend/src/app/pages/webhooks/webhooks.component.scss
@@ -1,0 +1,165 @@
+.page {
+  padding: 32px;
+  max-width: 1100px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.page-subtitle {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 4px;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.card-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.card-body {
+  padding: 18px;
+}
+
+.op-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 5px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.event-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+
+.event-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+
+  input { display: none; }
+
+  &.selected {
+    border-color: var(--accent);
+    background: var(--accent-dim);
+    color: var(--accent);
+  }
+}
+
+.loading-state {
+  display: flex;
+  justify-content: center;
+  padding: 60px;
+}
+
+.empty-state {
+  padding: 48px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.webhooks-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th {
+    padding: 10px 16px;
+    text-align: left;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+  }
+
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.875rem;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+.url-cell {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--accent);
+}
+
+.time-cell {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.action-btns {
+  display: flex;
+  gap: 6px;
+}
+
+.event-badges {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}

--- a/frontend/src/app/pages/webhooks/webhooks.component.ts
+++ b/frontend/src/app/pages/webhooks/webhooks.component.ts
@@ -1,0 +1,134 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { HugeiconsIconComponent } from '@hugeicons/angular';
+import {
+  RefreshIcon,
+  Share08Icon,
+  Add01Icon,
+  Delete01Icon,
+  CheckmarkCircle01Icon,
+  CancelCircleIcon,
+  ZapIcon,
+} from '@hugeicons/core-free-icons';
+import { ApexStoreService } from '../../services/apex-store.service';
+import { ToastService } from '../../services/toast.service';
+
+interface Webhook {
+  id: string;
+  url: string;
+  events: string[];
+  active: boolean;
+  created_at: number;
+  last_triggered_at?: number;
+  last_status?: string;
+}
+
+@Component({
+  selector: 'app-webhooks',
+  standalone: true,
+  imports: [FormsModule, DatePipe, HugeiconsIconComponent],
+  templateUrl: './webhooks.component.html',
+  styleUrl: './webhooks.component.scss'
+})
+export class WebhooksComponent implements OnInit {
+  private store = inject(ApexStoreService);
+  private toast = inject(ToastService);
+
+  readonly RefreshIcon = RefreshIcon;
+  readonly Share08Icon = Share08Icon;
+  readonly Add01Icon = Add01Icon;
+  readonly Delete01Icon = Delete01Icon;
+  readonly CheckmarkCircle01Icon = CheckmarkCircle01Icon;
+  readonly CancelCircleIcon = CancelCircleIcon;
+  readonly ZapIcon = ZapIcon;
+
+  webhooks = signal<Webhook[]>([]);
+  loading = signal(false);
+  creating = signal(false);
+  testing = signal<string | null>(null);
+
+  newUrl = '';
+  newEvents = 'key.set,key.delete';
+
+  allEventOptions = ['key.set', 'key.delete', 'key.get', 'note.created', 'note.updated', 'note.deleted', 'flush', 'compact'];
+
+  ngOnInit(): void { this.loadWebhooks(); }
+
+  loadWebhooks(): void {
+    this.loading.set(true);
+    this.store.listWebhooks().subscribe({
+      next: (data) => {
+        this.webhooks.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.toast.error('Failed to load webhooks');
+        this.loading.set(false);
+      }
+    });
+  }
+
+  createWebhook(): void {
+    const url = this.newUrl.trim();
+    if (!url) return;
+    const events = this.newEvents.split(',').map(e => e.trim()).filter(Boolean);
+    if (events.length === 0) return;
+
+    this.creating.set(true);
+    this.store.createWebhook(url, events).subscribe({
+      next: () => {
+        this.toast.success('Webhook created!');
+        this.newUrl = '';
+        this.creating.set(false);
+        this.loadWebhooks();
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Failed to create webhook');
+        this.creating.set(false);
+      }
+    });
+  }
+
+  deleteWebhook(id: string): void {
+    if (!confirm('Delete this webhook?')) return;
+    this.store.deleteWebhook(id).subscribe({
+      next: () => {
+        this.toast.success('Webhook deleted');
+        this.webhooks.update(list => list.filter(w => w.id !== id));
+      },
+      error: (e) => this.toast.error(e?.error?.message ?? 'Failed to delete webhook')
+    });
+  }
+
+  testWebhook(id: string): void {
+    this.testing.set(id);
+    this.store.testWebhook(id).subscribe({
+      next: () => {
+        this.toast.success('Test webhook sent!');
+        this.testing.set(null);
+      },
+      error: (e) => {
+        this.toast.error(e?.error?.message ?? 'Webhook test failed');
+        this.testing.set(null);
+      }
+    });
+  }
+
+  toggleEvent(event: string): void {
+    const events = this.newEvents.split(',').map(e => e.trim()).filter(Boolean);
+    if (events.includes(event)) {
+      this.newEvents = events.filter(e => e !== event).join(',');
+    } else {
+      this.newEvents = [...events, event].join(',');
+    }
+  }
+
+  isEventSelected(event: string): boolean {
+    return this.newEvents.split(',').map(e => e.trim()).includes(event);
+  }
+
+  nsToDate(ns: number): Date {
+    return new Date(ns / 1_000_000);
+  }
+}

--- a/frontend/src/app/services/apex-store.service.spec.ts
+++ b/frontend/src/app/services/apex-store.service.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ApexStoreService } from './apex-store.service';
+import { environment } from '../../environments/environment';
+
+describe('ApexStoreService', () => {
+  let service: ApexStoreService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ApexStoreService],
+    });
+    service = TestBed.inject(ApexStoreService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('put()', () => {
+    it('should POST to /keys with key and value', () => {
+      service.put('test-key', 'test-value').subscribe(res => {
+        expect(res.success).toBeTrue();
+        expect(res.data?.key).toBe('test-key');
+      });
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/keys`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ key: 'test-key', value: 'test-value' });
+      req.flush({ success: true, data: { key: 'test-key' } });
+    });
+  });
+
+  describe('get()', () => {
+    it('should GET from /keys/{key}', () => {
+      service.get('my-key').subscribe(res => {
+        expect(res.key).toBe('my-key');
+        expect(res.value).toBe('my-value');
+      });
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/keys/${encodeURIComponent('my-key')}`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: { key: 'my-key', value: 'my-value' } });
+    });
+  });
+
+  describe('delete()', () => {
+    it('should DELETE to /keys/{key}', () => {
+      service.delete('key-to-delete').subscribe(res => {
+        expect(res.success).toBeTrue();
+      });
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/keys/${encodeURIComponent('key-to-delete')}`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush({ success: true, data: null });
+    });
+  });
+
+  describe('listKeys()', () => {
+    it('should GET /keys and return key list', () => {
+      service.listKeys().subscribe(keys => {
+        expect(keys).toEqual(['a', 'b']);
+      });
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/keys`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: { keys: ['a', 'b'] } });
+    });
+  });
+
+  describe('getStats()', () => {
+    it('should GET /stats/all and return stats object', () => {
+      service.getStats().subscribe(stats => {
+        expect(stats['mem_records']).toBe(100);
+      });
+
+      const req = httpMock.expectOne(`${environment.apiUrl}/stats/all`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: { mem_records: 100 } });
+    });
+  });
+});

--- a/frontend/src/app/services/apex-store.service.ts
+++ b/frontend/src/app/services/apex-store.service.ts
@@ -285,6 +285,254 @@ export class ApexStoreService {
       .pipe(map(r => r.data?.subscriptions ?? []));
   }
 
+  // ── Replication ──────────────────────────────────────────────────────────
+
+  getReplicationTopology(): Observable<{ nodes: any[]; summary: any }> {
+    return this.http
+      .get<ApiResponse<{ nodes: any[]; summary: any }>>(`${this.baseUrl}/admin/replication`, this.opts())
+      .pipe(map(r => r.data ?? { nodes: [], summary: null }));
+  }
+
+  promoteReplica(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/replication/${id}/promote`, {}, this.opts());
+  }
+
+  removeReplica(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/replication/${id}`, this.opts());
+  }
+
+  // ── Vector Search ────────────────────────────────────────────────────────
+
+  listVectorIndexes(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ indexes: any[] }>>(`${this.baseUrl}/vector/indexes`, this.opts())
+      .pipe(map(r => r.data?.indexes ?? []));
+  }
+
+  createVectorIndex(name: string, dimension: number, metric: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/vector/indexes`, { name, dimension, metric }, this.opts());
+  }
+
+  deleteVectorIndex(name: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/vector/indexes/${encodeURIComponent(name)}`, this.opts());
+  }
+
+  vectorSearch(index: string, query: string): Observable<any[]> {
+    return this.http
+      .post<ApiResponse<{ results: any[] }>>(`${this.baseUrl}/vector/indexes/${encodeURIComponent(index)}/search`, { query }, this.opts())
+      .pipe(map(r => r.data?.results ?? []));
+  }
+
+  // ── Data Sync ────────────────────────────────────────────────────────────
+
+  listSyncJobs(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ jobs: any[] }>>(`${this.baseUrl}/admin/sync`, this.opts())
+      .pipe(map(r => r.data?.jobs ?? []));
+  }
+
+  createSyncJob(name: string, source: string, target: string, mode: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/sync`, { name, source, target, mode }, this.opts());
+  }
+
+  triggerSyncJob(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/sync/${id}/trigger`, {}, this.opts());
+  }
+
+  deleteSyncJob(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/sync/${id}`, this.opts());
+  }
+
+  // ── CDC ──────────────────────────────────────────────────────────────────
+
+  getCDCConfig(): Observable<{ config: any; tables: any[] }> {
+    return this.http
+      .get<ApiResponse<{ config: any; tables: any[] }>>(`${this.baseUrl}/admin/cdc`, this.opts())
+      .pipe(map(r => r.data ?? { config: {}, tables: [] }));
+  }
+
+  updateCDCConfig(config: any): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/admin/cdc`, config, this.opts());
+  }
+
+  addCDCTable(table: string, events: string[]): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/cdc/tables`, { table, events }, this.opts());
+  }
+
+  removeCDCTable(table: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/cdc/tables/${encodeURIComponent(table)}`, this.opts());
+  }
+
+  // ── Bulk Import / Export ─────────────────────────────────────────────────
+
+  listImportJobs(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ jobs: any[] }>>(`${this.baseUrl}/admin/imports`, this.opts())
+      .pipe(map(r => r.data?.jobs ?? []));
+  }
+
+  createImportJob(filename: string, format: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/imports`, { filename, format }, this.opts());
+  }
+
+  deleteImportJob(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/imports/${id}`, this.opts());
+  }
+
+  exportData(format: string): Observable<Blob> {
+    return this.http.get(`${this.baseUrl}/admin/export?format=${format}`, { ...this.opts(), responseType: 'blob' });
+  }
+
+  // ── Server Config ────────────────────────────────────────────────────────
+
+  getServerConfig(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ entries: any[] }>>(`${this.baseUrl}/admin/config`, this.opts())
+      .pipe(map(r => r.data?.entries ?? []));
+  }
+
+  updateServerConfig(key: string, value: string): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/admin/config/${encodeURIComponent(key)}`, { value }, this.opts());
+  }
+
+  // ── Chaos Engineering ────────────────────────────────────────────────────
+
+  listChaosExperiments(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ experiments: any[] }>>(`${this.baseUrl}/admin/chaos`, this.opts())
+      .pipe(map(r => r.data?.experiments ?? []));
+  }
+
+  createChaosExperiment(name: string, type: string, target: string, config: Record<string, unknown>): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/chaos`, { name, type, target, config }, this.opts());
+  }
+
+  toggleChaosExperiment(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/chaos/${id}/toggle`, {}, this.opts());
+  }
+
+  deleteChaosExperiment(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/chaos/${id}`, this.opts());
+  }
+
+  // ── Telemetry ────────────────────────────────────────────────────────────
+
+  getTelemetryConfig(): Observable<{ config: any; log_levels: any[] }> {
+    return this.http
+      .get<ApiResponse<{ config: any; log_levels: any[] }>>(`${this.baseUrl}/admin/telemetry`, this.opts())
+      .pipe(map(r => r.data ?? { config: {}, log_levels: [] }));
+  }
+
+  updateTelemetryConfig(config: any): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/admin/telemetry`, config, this.opts());
+  }
+
+  setLogLevel(module: string, level: string): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/admin/telemetry/log_levels/${encodeURIComponent(module)}`, { level }, this.opts());
+  }
+
+  // ── Quotas ───────────────────────────────────────────────────────────────
+
+  listQuotas(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ quotas: any[] }>>(`${this.baseUrl}/admin/quotas`, this.opts())
+      .pipe(map(r => r.data?.quotas ?? []));
+  }
+
+  createQuota(quota: any): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/quotas`, quota, this.opts());
+  }
+
+  updateQuota(id: string, quota: any): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/admin/quotas/${id}`, quota, this.opts());
+  }
+
+  deleteQuota(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/quotas/${id}`, this.opts());
+  }
+
+  // ── Data Scrubber ────────────────────────────────────────────────────────
+
+  listScrubberJobs(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ jobs: any[] }>>(`${this.baseUrl}/admin/scrubber`, this.opts())
+      .pipe(map(r => r.data?.jobs ?? []));
+  }
+
+  createScrubberJob(pattern: string, retention_days: number): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/scrubber`, { pattern, retention_days }, this.opts());
+  }
+
+  deleteScrubberJob(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/scrubber/${id}`, this.opts());
+  }
+
+  listIdempotencyKeys(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ keys: any[] }>>(`${this.baseUrl}/admin/idempotency`, this.opts())
+      .pipe(map(r => r.data?.keys ?? []));
+  }
+
+  deleteIdempotencyKey(key: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/idempotency/${encodeURIComponent(key)}`, this.opts());
+  }
+
+  // ── Backpressure & Retry ─────────────────────────────────────────────────
+
+  getBackpressureConfig(): Observable<any> {
+    return this.http
+      .get<ApiResponse<any>>(`${this.baseUrl}/admin/backpressure`, this.opts())
+      .pipe(map(r => r.data ?? {}));
+  }
+
+  updateBackpressureConfig(config: any): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/admin/backpressure`, config, this.opts());
+  }
+
+  // ── WASM Plugins ─────────────────────────────────────────────────────────
+
+  listWasmPlugins(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ plugins: any[] }>>(`${this.baseUrl}/admin/wasm`, this.opts())
+      .pipe(map(r => r.data?.plugins ?? []));
+  }
+
+  uploadWasmPlugin(file: File): Observable<ApiResponse<null>> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/wasm`, formData, { headers: this.headers });
+  }
+
+  toggleWasmPlugin(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/wasm/${id}/toggle`, {}, this.opts());
+  }
+
+  deleteWasmPlugin(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/wasm/${id}`, this.opts());
+  }
+
+  // ── CI/CD Fixtures ───────────────────────────────────────────────────────
+
+  listCICDFixtures(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ fixtures: any[] }>>(`${this.baseUrl}/admin/cicd`, this.opts())
+      .pipe(map(r => r.data?.fixtures ?? []));
+  }
+
+  createCICDFixture(name: string, description: string, type: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/cicd`, { name, description, type }, this.opts());
+  }
+
+  deleteCICDFixture(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/cicd/${id}`, this.opts());
+  }
+
+  generateTestData(count: number): Observable<{ records_generated: number; elapsed_ms: number }> {
+    return this.http
+      .post<ApiResponse<{ records_generated: number; elapsed_ms: number }>>(`${this.baseUrl}/admin/cicd/generate`, { count }, this.opts())
+      .pipe(map(r => r.data ?? { records_generated: 0, elapsed_ms: 0 }));
+  }
+
   // ── SQL Runner ──────────────────────────────────────────────────────────
 
   executeQuery(query: string): Observable<any> {

--- a/frontend/src/app/services/apex-store.service.ts
+++ b/frontend/src/app/services/apex-store.service.ts
@@ -182,4 +182,138 @@ export class ApexStoreService {
   deleteToken(id: string): Observable<ApiResponse<null>> {
     return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/tokens/${id}`, this.opts());
   }
+
+  // ── Compaction ──────────────────────────────────────────────────────────
+
+  flush(): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/flush`, {}, this.opts());
+  }
+
+  compact(): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/compact`, {}, this.opts());
+  }
+
+  // ── Rate Limits ─────────────────────────────────────────────────────────
+
+  getRateLimits(): Observable<Record<string, unknown>> {
+    return this.http
+      .get<ApiResponse<Record<string, unknown>>>(`${this.baseUrl}/admin/rate_limits`, this.opts())
+      .pipe(map(r => r.data ?? {}));
+  }
+
+  // ── Backups ──────────────────────────────────────────────────────────────
+
+  listBackups(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ backups: any[] }>>(`${this.baseUrl}/admin/backups`, this.opts())
+      .pipe(map(r => r.data?.backups ?? []));
+  }
+
+  createBackup(name: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/backups`, { name }, this.opts());
+  }
+
+  restoreBackup(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/backups/${id}/restore`, {}, this.opts());
+  }
+
+  deleteBackup(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/backups/${id}`, this.opts());
+  }
+
+  // ── Snapshots (Time Travel) ─────────────────────────────────────────────
+
+  listSnapshots(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ snapshots: any[] }>>(`${this.baseUrl}/notes/snapshots`, this.opts())
+      .pipe(map(r => r.data?.snapshots ?? []));
+  }
+
+  createSnapshot(name: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/notes/snapshots`, { name }, this.opts());
+  }
+
+  getSnapshotNotes(id: string): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ notes: any[] }>>(`${this.baseUrl}/notes/snapshots/${id}`, this.opts())
+      .pipe(map(r => r.data?.notes ?? []));
+  }
+
+  restoreSnapshot(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/notes/snapshots/${id}/restore`, {}, this.opts());
+  }
+
+  deleteSnapshot(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/notes/snapshots/${id}`, this.opts());
+  }
+
+  // ── Webhooks ────────────────────────────────────────────────────────────
+
+  listWebhooks(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ webhooks: any[] }>>(`${this.baseUrl}/admin/webhooks`, this.opts())
+      .pipe(map(r => r.data?.webhooks ?? []));
+  }
+
+  createWebhook(url: string, events: string[]): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/webhooks`, { url, events }, this.opts());
+  }
+
+  deleteWebhook(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/webhooks/${id}`, this.opts());
+  }
+
+  testWebhook(id: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/webhooks/${id}/test`, {}, this.opts());
+  }
+
+  // ── Pub/Sub ─────────────────────────────────────────────────────────────
+
+  listTopics(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ topics: any[] }>>(`${this.baseUrl}/pubsub/topics`, this.opts())
+      .pipe(map(r => r.data?.topics ?? []));
+  }
+
+  publishMessage(topic: string, message: string): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/pubsub/topics/${encodeURIComponent(topic)}`, { message }, this.opts());
+  }
+
+  listSubscriptions(topic: string): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ subscriptions: any[] }>>(`${this.baseUrl}/pubsub/topics/${encodeURIComponent(topic)}/subscriptions`, this.opts())
+      .pipe(map(r => r.data?.subscriptions ?? []));
+  }
+
+  // ── SQL Runner ──────────────────────────────────────────────────────────
+
+  executeQuery(query: string): Observable<any> {
+    return this.http
+      .post<ApiResponse<any>>(`${this.baseUrl}/query`, { query }, this.opts())
+      .pipe(map(r => r.data ?? { columns: [], rows: [], row_count: 0, elapsed_ms: 0 }));
+  }
+
+  // ── Resilience / Circuit Breakers ───────────────────────────────────────
+
+  getCircuitBreakers(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ circuit_breakers: any[] }>>(`${this.baseUrl}/admin/circuit_breakers`, this.opts())
+      .pipe(map(r => r.data?.circuit_breakers ?? []));
+  }
+
+  // ── Access Control / Policies ───────────────────────────────────────────
+
+  listPolicies(): Observable<any[]> {
+    return this.http
+      .get<ApiResponse<{ policies: any[] }>>(`${this.baseUrl}/admin/policies`, this.opts())
+      .pipe(map(r => r.data?.policies ?? []));
+  }
+
+  createPolicy(name: string, resource: string, actions: string[], effect: string, priority: number): Observable<ApiResponse<null>> {
+    return this.http.post<ApiResponse<null>>(`${this.baseUrl}/admin/policies`, { name, resource, actions, effect, priority }, this.opts());
+  }
+
+  deletePolicy(id: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/admin/policies/${id}`, this.opts());
+  }
 }

--- a/frontend/src/app/services/apex-store.service.ts
+++ b/frontend/src/app/services/apex-store.service.ts
@@ -18,6 +18,29 @@ export interface ApiToken {
 }
 export type Permission = 'Read' | 'Write' | 'Delete' | 'Admin';
 
+export interface Note {
+  path: string;
+  content: string;
+  updated_at?: number;
+}
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type?: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  label?: string;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
 interface ApiResponse<T> {
   success: boolean;
   message: string;
@@ -73,6 +96,51 @@ export class ApexStoreService {
     return this.http
       .get<ApiResponse<{ records: SearchResult[] }>>(`${this.baseUrl}/scan`, this.opts())
       .pipe(map(r => r.data?.records ?? []));
+  }
+
+  // ── Notes ─────────────────────────────────────────────────────────────────
+
+  getNotes(prefix?: string): Observable<Note[]> {
+    const params = prefix ? `?prefix=${encodeURIComponent(prefix)}` : '';
+    return this.http
+      .get<ApiResponse<{ notes: Note[] }>>(`${this.baseUrl}/notes${params}`, this.opts())
+      .pipe(map(r => r.data?.notes ?? []));
+  }
+
+  getNote(path: string): Observable<Note> {
+    return this.http
+      .get<ApiResponse<Note>>(`${this.baseUrl}/notes/${encodeURIComponent(path)}`, this.opts())
+      .pipe(map(r => r.data!));
+  }
+
+  putNote(path: string, content: string): Observable<ApiResponse<null>> {
+    return this.http.put<ApiResponse<null>>(`${this.baseUrl}/notes/${encodeURIComponent(path)}`, { content }, this.opts());
+  }
+
+  deleteNote(path: string): Observable<ApiResponse<null>> {
+    return this.http.delete<ApiResponse<null>>(`${this.baseUrl}/notes/${encodeURIComponent(path)}`, this.opts());
+  }
+
+  // ── Notes Graph ───────────────────────────────────────────────────────────
+
+  getGraphData(path: string, depth: number = 1): Observable<GraphData> {
+    return this.http
+      .get<ApiResponse<GraphData>>(`${this.baseUrl}/notes/${encodeURIComponent(path)}/graph?depth=${depth}`, this.opts())
+      .pipe(map(r => r.data ?? { nodes: [], edges: [] }));
+  }
+
+  // ── Tags ──────────────────────────────────────────────────────────────────
+
+  getTags(): Observable<string[]> {
+    return this.http
+      .get<ApiResponse<{ tags: string[] }>>(`${this.baseUrl}/tags`, this.opts())
+      .pipe(map(r => r.data?.tags ?? []));
+  }
+
+  getTagNotes(tag: string): Observable<Note[]> {
+    return this.http
+      .get<ApiResponse<{ notes: Note[] }>>(`${this.baseUrl}/tags/${encodeURIComponent(tag)}/notes`, this.opts())
+      .pipe(map(r => r.data?.notes ?? []));
   }
 
   // ── Stats ─────────────────────────────────────────────────────────────────

--- a/frontend/src/app/services/apex-store.service.ts
+++ b/frontend/src/app/services/apex-store.service.ts
@@ -533,6 +533,13 @@ export class ApexStoreService {
       .pipe(map(r => r.data ?? { records_generated: 0, elapsed_ms: 0 }));
   }
 
+  // ── GraphQL ────────────────────────────────────────────────────────────
+
+  executeGraphQL(query: string): Observable<any> {
+    return this.http
+      .post<any>(`${this.baseUrl}/graphql`, { query }, this.opts());
+  }
+
   // ── SQL Runner ──────────────────────────────────────────────────────────
 
   executeQuery(query: string): Observable<any> {

--- a/frontend/src/app/services/sync.service.ts
+++ b/frontend/src/app/services/sync.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, NgZone, signal } from '@angular/core';
+import { Observable, Subject, filter, map } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface SyncChange {
+  key: string;
+  value: string;
+  timestamp: number;
+  deviceId: string;
+}
+
+export type SyncStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+@Injectable({ providedIn: 'root' })
+export class SyncService {
+  private ws: WebSocket | null = null;
+  private baseUrl = environment.apiUrl.replace('http', 'ws');
+  private messageSubject = new Subject<SyncChange>();
+  private statusSubject = new Subject<SyncStatus>();
+  private pingInterval: ReturnType<typeof setInterval> | null = null;
+  private deviceId = '';
+
+  readonly status = signal<SyncStatus>('disconnected');
+  readonly pendingChanges = signal<number>(0);
+  readonly lastSyncTimestamp = signal<number | null>(null);
+  readonly lastError = signal<string | null>(null);
+
+  constructor(private ngZone: NgZone) {}
+
+  get onMessage(): Observable<SyncChange> {
+    return this.messageSubject.asObservable();
+  }
+
+  get onStatusChange(): Observable<SyncStatus> {
+    return this.statusSubject.asObservable();
+  }
+
+  connect(deviceId: string): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      return; // already connected
+    }
+    this.deviceId = deviceId;
+    this.setStatus('connecting');
+
+    try {
+      const wsUrl = `${this.baseUrl}/ws/sync?device_id=${encodeURIComponent(deviceId)}`;
+      this.ws = new WebSocket(wsUrl);
+
+      this.ws.onopen = () => {
+        this.ngZone.run(() => {
+          this.setStatus('connected');
+          this.lastError.set(null);
+          this.startPing();
+        });
+      };
+
+      this.ws.onmessage = (event: MessageEvent) => {
+        this.ngZone.run(() => {
+          try {
+            const msg = JSON.parse(event.data);
+            if (msg.type === 'sync_push' && msg.changes) {
+              for (const change of msg.changes) {
+                this.messageSubject.next({
+                  key: change.key,
+                  value: change.value,
+                  timestamp: change.timestamp,
+                  deviceId: change.device_id || 'server',
+                });
+              }
+            }
+            if (msg.type === 'sync_ack') {
+              this.lastSyncTimestamp.set(msg.ack_timestamp);
+            }
+          } catch {
+            // ignore malformed messages
+          }
+        });
+      };
+
+      this.ws.onclose = () => {
+        this.ngZone.run(() => {
+          this.stopPing();
+          this.setStatus('disconnected');
+          this.ws = null;
+        });
+      };
+
+      this.ws.onerror = () => {
+        this.ngZone.run(() => {
+          this.lastError.set('WebSocket connection error');
+          this.setStatus('error');
+        });
+      };
+    } catch {
+      this.ngZone.run(() => {
+        this.lastError.set('Failed to create WebSocket connection');
+        this.setStatus('error');
+      });
+    }
+  }
+
+  disconnect(): void {
+    this.stopPing();
+    if (this.ws) {
+      this.ws.onclose = null; // prevent reconnect logic
+      this.ws.close(1000, 'Client disconnect');
+      this.ws = null;
+    }
+    this.setStatus('disconnected');
+    this.lastSyncTimestamp.set(null);
+    this.pendingChanges.set(0);
+  }
+
+  pushChange(key: string, value: string): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.lastError.set('Cannot push change: not connected');
+      return;
+    }
+
+    const change = {
+      type: 'sync_push',
+      changes: [
+        {
+          key,
+          value,
+          timestamp: Date.now(),
+          device_id: this.deviceId,
+        },
+      ],
+      last_ack: this.lastSyncTimestamp() ?? 0,
+    };
+
+    try {
+      this.ws.send(JSON.stringify(change));
+      this.pendingChanges.update(n => n + 1);
+    } catch {
+      this.lastError.set('Failed to send change');
+    }
+  }
+
+  private setStatus(s: SyncStatus): void {
+    this.status.set(s);
+    this.statusSubject.next(s);
+  }
+
+  private startPing(): void {
+    this.stopPing();
+    this.pingInterval = setInterval(() => {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        try {
+          this.ws.send(JSON.stringify({ type: 'ping' }));
+        } catch {
+          // ignore ping failures
+        }
+      }
+    }, 30000);
+  }
+
+  private stopPing(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+  }
+}

--- a/frontend/src/app/services/toast.service.spec.ts
+++ b/frontend/src/app/services/toast.service.spec.ts
@@ -1,0 +1,108 @@
+import { TestBed } from '@angular/core/testing';
+import { ToastService } from './toast.service';
+
+describe('ToastService', () => {
+  let service: ToastService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ToastService],
+    });
+    service = TestBed.inject(ToastService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should start with an empty toast list', () => {
+    expect(service.toasts().length).toBe(0);
+  });
+
+  describe('show()', () => {
+    it('should add a toast with the given message and type', () => {
+      service.show('Hello world', 'success');
+      const toasts = service.toasts();
+      expect(toasts.length).toBe(1);
+      expect(toasts[0].message).toBe('Hello world');
+      expect(toasts[0].type).toBe('success');
+    });
+
+    it('should assign incrementing IDs', () => {
+      service.show('First');
+      service.show('Second');
+      const toasts = service.toasts();
+      expect(toasts[0].id).toBe(0);
+      expect(toasts[1].id).toBe(1);
+    });
+
+    it('should default type to info', () => {
+      service.show('Info toast');
+      expect(service.toasts()[0].type).toBe('info');
+    });
+  });
+
+  describe('dismiss()', () => {
+    it('should remove the toast with the given ID', () => {
+      service.show('Toast A');
+      service.show('Toast B');
+      expect(service.toasts().length).toBe(2);
+
+      service.dismiss(0);
+      expect(service.toasts().length).toBe(1);
+      expect(service.toasts()[0].message).toBe('Toast B');
+    });
+
+    it('should do nothing if the ID does not exist', () => {
+      service.show('Only toast');
+      service.dismiss(99);
+      expect(service.toasts().length).toBe(1);
+    });
+  });
+
+  describe('helper methods', () => {
+    it('success() should add a success toast', () => {
+      service.success('OK!');
+      expect(service.toasts()[0].type).toBe('success');
+    });
+
+    it('error() should add an error toast', () => {
+      service.error('Fail!');
+      expect(service.toasts()[0].type).toBe('error');
+    });
+
+    it('info() should add an info toast', () => {
+      service.info('Note');
+      expect(service.toasts()[0].type).toBe('info');
+    });
+  });
+
+  describe('auto-dismiss', () => {
+    beforeEach(() => {
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
+
+    it('should remove toast after the default duration (3500ms)', () => {
+      service.show('Auto dismiss');
+      expect(service.toasts().length).toBe(1);
+
+      jasmine.clock().tick(3500);
+      expect(service.toasts().length).toBe(0);
+    });
+
+    it('should remove toast after a custom duration', () => {
+      service.show('Custom duration', 'info', 1000);
+      expect(service.toasts().length).toBe(1);
+
+      jasmine.clock().tick(999);
+      expect(service.toasts().length).toBe(1);
+
+      jasmine.clock().tick(1);
+      expect(service.toasts().length).toBe(0);
+    });
+  });
+});

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -39,6 +39,19 @@ body {
   line-height: 1.6;
 }
 
+.light-mode {
+  --bg-primary: #f8fafc;
+  --bg-secondary: #f1f5f9;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f8fafc;
+  --border: #e2e8f0;
+  --border-light: #cbd5e1;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --shadow: 0 4px 24px rgba(0,0,0,0.08);
+}
+
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: var(--bg-secondary); }
 ::-webkit-scrollbar-thumb { background: var(--border-light); border-radius: 3px; }

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,0 +1,27 @@
+// This file is required by karma.conf.js and loads recursively all the .spec
+// and framework files.
+
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+  {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  }
+);
+
+// Then we find all the tests.
+const context = (import.meta as any).webpackContext
+  ? (import.meta as any).webpackContext('./', true, /\.spec\.ts$/)
+  : require.context('./', true, /\.spec\.ts$/);
+
+// And load the modules.
+context.keys().forEach(context);

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, Mutex};
 pub struct KeysQuery {
     prefix: Option<String>,
     limit: Option<usize>,
+    q: Option<String>,
 }
 
 /// Request body for `PUT /keys/{key}`
@@ -298,6 +299,168 @@ async fn graphql_playground() -> HttpResponse {
         .body(html)
 }
 
+// ── Frontend-compatibility endpoints ─────────────────────────────────────
+
+/// Request body for `POST /keys` (frontend-compatible key-value pair).
+#[derive(Deserialize)]
+pub struct FrontendSetBody {
+    key: String,
+    value: String,
+}
+
+/// Request body for `POST /keys/batch`.
+#[derive(Deserialize)]
+pub struct BatchBody {
+    records: Vec<FrontendSetBody>,
+}
+
+/// Handler for `GET /stats/all` — frontend-compatible full stats endpoint.
+#[get("/stats/all")]
+async fn get_stats_all(req: HttpRequest, engine: web::Data<LsmEngine>) -> impl Responder {
+    if let Err(e) = require_permission(&req, Permission::Read) {
+        return e;
+    }
+    match engine.stats("default") {
+        Ok(stats) => HttpResponse::Ok().content_type("application/json").json(
+            json!({ "success": true, "data": {
+                "mem_records": stats.mem_records,
+                "mem_kb": stats.mem_kb,
+                "sst_kb": stats.sst_kb,
+                "sst_files": stats.sst_files,
+                "wal_kb": stats.wal_kb,
+                "total_records": stats.total_records,
+            }}),
+        ),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api", "Failed to get stats/all: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "success": false, "message": "internal server error" }))
+        }
+    }
+}
+
+/// Handler for `POST /keys` — frontend-compatible key insert (like PUT but with body key).
+#[post("/keys")]
+async fn post_key(
+    req: HttpRequest,
+    engine: web::Data<LsmEngine>,
+    body: web::Json<FrontendSetBody>,
+) -> impl Responder {
+    if let Err(e) = require_permission(&req, Permission::Write) {
+        return e;
+    }
+    match engine.put_cf(
+        "default",
+        body.key.as_bytes().to_vec(),
+        body.value.as_bytes().to_vec(),
+    ) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "success": true, "data": { "key": body.key } })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api", "Failed to set key: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "success": false, "message": "internal server error" }))
+        }
+    }
+}
+
+/// Handler for `GET /keys/search` — search keys by prefix or query.
+#[get("/keys/search")]
+async fn search_keys(
+    req: HttpRequest,
+    engine: web::Data<LsmEngine>,
+    query: web::Query<KeysQuery>,
+) -> impl Responder {
+    if let Err(e) = require_permission(&req, Permission::Read) {
+        return e;
+    }
+    let limit = query
+        .limit
+        .unwrap_or(100)
+        .min(crate::core::engine::MAX_SCAN_LIMIT);
+    // Use `q` if provided (frontend compatibility), otherwise fall back to `prefix`
+    let prefix = query.q.as_deref().or(query.prefix.as_deref()).unwrap_or("");
+    let (results, _cursor) = match engine.search_prefix(prefix, None, limit) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(target: "apexstore::api", "Failed to search keys: {:?}", e);
+            return HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "success": false, "message": "internal server error" }));
+        }
+    };
+    let records: Vec<serde_json::Value> = results
+        .into_iter()
+        .map(|(k, v)| json!({ "key": String::from_utf8_lossy(&k), "value": String::from_utf8_lossy(&v) }))
+        .collect();
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .json(json!({ "success": true, "data": { "records": records } }))
+}
+
+/// Handler for `POST /keys/batch` — batch insert.
+#[post("/keys/batch")]
+async fn batch_keys(
+    req: HttpRequest,
+    engine: web::Data<LsmEngine>,
+    body: web::Json<BatchBody>,
+) -> impl Responder {
+    if let Err(e) = require_permission(&req, Permission::Write) {
+        return e;
+    }
+    let mut count = 0;
+    for record in &body.records {
+        if engine
+            .put_cf(
+                "default",
+                record.key.as_bytes().to_vec(),
+                record.value.as_bytes().to_vec(),
+            )
+            .is_ok()
+        {
+            count += 1;
+        }
+    }
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .json(json!({ "success": true, "data": { "count": count } }))
+}
+
+/// Handler for `GET /scan` — full scan of all keys.
+#[get("/scan")]
+async fn scan_keys(req: HttpRequest, engine: web::Data<LsmEngine>) -> impl Responder {
+    if let Err(e) = require_permission(&req, Permission::Read) {
+        return e;
+    }
+    match engine.keys() {
+        Ok(keys) => {
+            let records: Vec<serde_json::Value> = keys
+                .into_iter()
+                .filter_map(|k| {
+                    let key_str = String::from_utf8_lossy(&k).to_string();
+                    engine
+                        .get_cf("default", key_str.as_bytes())
+                        .ok()
+                        .flatten()
+                        .map(|v| json!({ "key": key_str, "value": String::from_utf8_lossy(&v) }))
+                })
+                .collect();
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .json(json!({ "success": true, "data": { "records": records } }))
+        }
+        Err(e) => {
+            tracing::error!(target: "apexstore::api", "Failed to scan keys: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "success": false, "message": "internal server error" }))
+        }
+    }
+}
+
 // ── Route configuration ───────────────────────────────────────────────────
 
 /// Register API routes.
@@ -306,8 +469,13 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(get_key)
         .service(put_key)
         .service(delete_key)
+        .service(post_key)
+        .service(search_keys)
+        .service(batch_keys)
+        .service(scan_keys)
         .service(get_metrics)
         .service(get_stats)
+        .service(get_stats_all)
         .service(admin_flush)
         .service(admin_compact)
         .service(admin_rate_limits)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod config;
 pub mod graphql;
 pub mod health;
+pub mod notes;
 pub mod rate_limiter;
 pub mod timeout_middleware;
 
@@ -315,6 +316,8 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         .service(health::liveness)
         .service(health::readiness)
         .service(health::startup)
+        // Notes & Tags endpoints
+        .configure(notes::configure)
         // GraphQL endpoints
         .route("/graphql", web::post().to(graphql_handler))
         .route("/graphql", web::get().to(graphql_handler))
@@ -379,6 +382,7 @@ pub async fn start_server(engine: Arc<LsmEngine>, config: ServerConfig) -> std::
     let token_manager = web::Data::new(TokenManager::new_with_engine(engine.clone()));
     let auth_enabled = web::Data::new(config.auth.enabled);
     let graphql_schema = web::Data::new(graphql::build_schema(engine.clone()));
+    let note_engine = web::Data::new(crate::notes::NoteEngine::new(engine.clone()));
 
     let cors_enabled = config.cors_enabled;
     let cors_origins = config.cors_origins.clone();
@@ -401,6 +405,7 @@ pub async fn start_server(engine: Arc<LsmEngine>, config: ServerConfig) -> std::
             .app_data(token_manager.clone())
             .app_data(auth_enabled.clone())
             .app_data(graphql_schema.clone())
+            .app_data(note_engine.clone())
             .app_data(access_controller.clone())
             .app_data(access_control_enabled.clone())
             .configure(configure)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod graphql;
 pub mod health;
 pub mod notes;
 pub mod rate_limiter;
+pub mod sync;
 pub mod timeout_middleware;
 
 use self::access_control::AccessControl;
@@ -489,7 +490,9 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         // GraphQL endpoints
         .route("/graphql", web::post().to(graphql_handler))
         .route("/graphql", web::get().to(graphql_handler))
-        .route("/graphql/playground", web::get().to(graphql_playground));
+        .route("/graphql/playground", web::get().to(graphql_playground))
+        // WebSocket sync endpoint
+        .service(sync::sync_handler);
 }
 
 /// Build CORS middleware from configuration.
@@ -554,6 +557,7 @@ pub async fn start_server(engine: Arc<LsmEngine>, config: ServerConfig) -> std::
     let time_travel_engine = web::Data::new(Mutex::new(
         crate::infra::time_travel::TimeTravelEngine::new(100),
     ));
+    let sync_manager = web::Data::new(sync::SyncManager::new());
 
     let cors_enabled = config.cors_enabled;
     let cors_origins = config.cors_origins.clone();
@@ -578,6 +582,7 @@ pub async fn start_server(engine: Arc<LsmEngine>, config: ServerConfig) -> std::
             .app_data(graphql_schema.clone())
             .app_data(note_engine.clone())
             .app_data(time_travel_engine.clone())
+            .app_data(sync_manager.clone())
             .app_data(access_controller.clone())
             .app_data(access_control_enabled.clone())
             .configure(configure)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,7 +23,7 @@ use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use serde::Deserialize;
 use serde_json::json;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Query parameters for `GET /keys`
 #[derive(Deserialize)]
@@ -383,6 +383,9 @@ pub async fn start_server(engine: Arc<LsmEngine>, config: ServerConfig) -> std::
     let auth_enabled = web::Data::new(config.auth.enabled);
     let graphql_schema = web::Data::new(graphql::build_schema(engine.clone()));
     let note_engine = web::Data::new(crate::notes::NoteEngine::new(engine.clone()));
+    let time_travel_engine = web::Data::new(Mutex::new(
+        crate::infra::time_travel::TimeTravelEngine::new(100),
+    ));
 
     let cors_enabled = config.cors_enabled;
     let cors_origins = config.cors_origins.clone();
@@ -406,6 +409,7 @@ pub async fn start_server(engine: Arc<LsmEngine>, config: ServerConfig) -> std::
             .app_data(auth_enabled.clone())
             .app_data(graphql_schema.clone())
             .app_data(note_engine.clone())
+            .app_data(time_travel_engine.clone())
             .app_data(access_controller.clone())
             .app_data(access_control_enabled.clone())
             .configure(configure)

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -18,6 +18,7 @@ use crate::notes::{GraphConfig, GraphDepth, NotesEngine};
 use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse, Responder};
 use serde::Deserialize;
 use serde_json::json;
+use std::sync::Mutex;
 
 /// Query parameters for `GET /notes`
 #[derive(Deserialize)]
@@ -50,6 +51,12 @@ pub struct TagNotesQuery {
 #[derive(Deserialize)]
 pub struct RenameBody {
     new_path: String,
+}
+
+/// Query parameters for `POST /notes/{path}/restore`
+#[derive(Deserialize)]
+pub struct RestoreQuery {
+    timestamp: u128,
 }
 
 // ── Handlers ────────────────────────────────────────────────────────────────
@@ -130,7 +137,7 @@ async fn put_note(
         return e;
     }
     let note_path = path.into_inner();
-    match engine.put_note(&note_path, &body.content) {
+    match engine.put_note_with_version(&note_path, &body.content) {
         Ok(_) => HttpResponse::Ok()
             .content_type("application/json")
             .json(json!({ "status": "ok", "path": note_path })),
@@ -289,6 +296,153 @@ async fn get_graph(
     }
 }
 
+/// `GET /notes/{path}/history` — list version history for a note.
+#[get("/{path}/history")]
+async fn get_version_history(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.get_version_history(&note_path) {
+        Ok(timestamps) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "path": note_path, "versions": timestamps })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get version history: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /notes/{path}/history/{timestamp}` — get note at a specific version.
+#[get("/{path}/history/{timestamp}")]
+async fn get_note_at_version(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<(String, u128)>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let (note_path, timestamp) = path.into_inner();
+    match engine.get_note_at_version(&note_path, timestamp) {
+        Ok(Some(content)) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "path": note_path, "timestamp": timestamp, "content": content })),
+        Ok(None) => HttpResponse::NotFound()
+            .content_type("application/json")
+            .json(json!({ "error": "version not found" })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get note at version: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `DELETE /notes/{path}/history/{timestamp}` — remove a specific version.
+#[delete("/{path}/history/{timestamp}")]
+async fn delete_version(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<(String, u128)>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Delete) {
+        return e;
+    }
+    let (note_path, timestamp) = path.into_inner();
+    match engine.remove_version(&note_path, timestamp) {
+        Ok(true) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok" })),
+        Ok(false) => HttpResponse::NotFound()
+            .content_type("application/json")
+            .json(json!({ "error": "version not found" })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to remove version: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `POST /notes/{path}/restore?timestamp=...` — restore note from a version.
+#[post("/{path}/restore")]
+async fn restore_version(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    query: web::Query<RestoreQuery>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Write) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.restore_version(&note_path, query.timestamp) {
+        Ok(true) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok", "path": note_path, "restored_from": query.timestamp })),
+        Ok(false) => HttpResponse::NotFound()
+            .content_type("application/json")
+            .json(json!({ "error": "version not found" })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to restore version: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `POST /notes/{path}/snapshot` — create a manual TimeTravel snapshot.
+#[post("/{path}/snapshot")]
+async fn create_snapshot(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    time_travel: web::Data<Mutex<crate::infra::time_travel::TimeTravelEngine>>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Admin) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    let content = match engine.get_note(&note_path) {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            return HttpResponse::NotFound()
+                .content_type("application/json")
+                .json(json!({ "error": "note not found" }))
+        }
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get note: {:?}", e);
+            return HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }));
+        }
+    };
+
+    let mut data = std::collections::HashMap::new();
+    data.insert(
+        format!("note:{}", note_path).into_bytes(),
+        content.into_bytes(),
+    );
+
+    let mut tt = time_travel.lock().unwrap();
+    let ts = tt.capture(data, &format!("manual-snapshot-{}", note_path));
+
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .json(json!({ "status": "ok", "timestamp": ts }))
+}
+
 /// `GET /tags` — list all tags.
 #[get("/tags")]
 async fn list_tags(req: HttpRequest, engine: web::Data<NotesEngine>) -> impl Responder {
@@ -358,7 +512,12 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .service(rename_note)
             .service(get_backlinks)
             .service(get_forward_links)
-            .service(get_graph),
+            .service(get_graph)
+            .service(get_version_history)
+            .service(get_note_at_version)
+            .service(delete_version)
+            .service(restore_version)
+            .service(create_snapshot),
     )
     .service(list_tags)
     .service(get_notes_by_tag);

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -532,6 +532,114 @@ async fn search_notes(
     }
 }
 
+// ── Template handlers ───────────────────────────────────────────────────────
+
+/// `GET /templates` — list all saved templates.
+#[get("/templates")]
+async fn list_templates_handler(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    match crate::notes::template::list_templates(&engine) {
+        Ok(templates) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "templates": templates })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to list templates: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// Request body for `PUT /templates/{name}`.
+#[derive(Deserialize)]
+pub struct PutTemplateBody {
+    content: String,
+}
+
+/// `PUT /templates/{name}` — save a template.
+#[put("/templates/{name}")]
+async fn save_template_handler(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    body: web::Json<PutTemplateBody>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Write) {
+        return e;
+    }
+    let name = path.into_inner();
+    match crate::notes::template::save_template(&engine, &name, &body.content) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok", "name": name })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to save template: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `DELETE /templates/{name}` — delete a template.
+#[delete("/templates/{name}")]
+async fn delete_template_handler(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Delete) {
+        return e;
+    }
+    let name = path.into_inner();
+    match crate::notes::template::delete_template(&engine, &name) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok" })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to delete template: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// Request body for `POST /notes/daily`.
+#[derive(Deserialize)]
+pub struct CreateDailyNoteBody {
+    template: Option<String>,
+}
+
+/// `POST /notes/daily` — create a daily note, optionally from a template.
+#[post("/daily")]
+async fn create_daily_note_handler(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    body: web::Json<CreateDailyNoteBody>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Write) {
+        return e;
+    }
+    match crate::notes::template::create_daily_note(&engine, body.template.as_deref()) {
+        Ok(path) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok", "path": path })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to create daily note: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
 /// Register all notes API routes under `/notes` and `/tags`.
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
@@ -548,9 +656,13 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .service(get_note_at_version)
             .service(delete_version)
             .service(restore_version)
-            .service(create_snapshot),
+            .service(create_snapshot)
+            .service(create_daily_note_handler),
     )
     .service(search_notes)
     .service(list_tags)
-    .service(get_notes_by_tag);
+    .service(get_notes_by_tag)
+    .service(list_templates_handler)
+    .service(save_template_handler)
+    .service(delete_template_handler);
 }

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -59,6 +59,13 @@ pub struct RestoreQuery {
     timestamp: u128,
 }
 
+/// Query parameters for `GET /search`
+#[derive(Deserialize)]
+pub struct SearchQuery {
+    q: String,
+    limit: Option<usize>,
+}
+
 // ── Handlers ────────────────────────────────────────────────────────────────
 
 /// `GET /notes` — list all notes with optional prefix filter.
@@ -501,6 +508,30 @@ async fn get_notes_by_tag(
 
 // ── Route configuration ─────────────────────────────────────────────────────
 
+/// `GET /search?q=...` — full-text search across all notes.
+#[get("/search")]
+async fn search_notes(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    query: web::Query<SearchQuery>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let max_results = query.limit.unwrap_or(20).min(100);
+    match engine.search_notes(&query.q, max_results) {
+        Ok(results) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "results": results, "query": query.q })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Search failed: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "search failed" }))
+        }
+    }
+}
+
 /// Register all notes API routes under `/notes` and `/tags`.
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
@@ -519,6 +550,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             .service(restore_version)
             .service(create_snapshot),
     )
+    .service(search_notes)
     .service(list_tags)
     .service(get_notes_by_tag);
 }

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -1,0 +1,365 @@
+//! Notes CRUD and graph REST API endpoints.
+//!
+//! Provides the following endpoints:
+//!
+//! - `GET    /notes`                          — List all notes
+//! - `GET    /notes/{path}`                   — Get a note
+//! - `PUT    /notes/{path}`                   — Create or update a note
+//! - `DELETE /notes/{path}`                   — Delete a note
+//! - `POST   /notes/{path}/rename`            — Rename a note
+//! - `GET    /notes/{path}/backlinks`         — List backlinks
+//! - `GET    /notes/{path}/links`             — List forward links
+//! - `GET    /notes/{path}/graph`             — Graph view data
+//! - `GET    /tags`                           — List all tags
+//! - `GET    /tags/{tag}/notes`               — List notes by tag
+
+use crate::infra::error::LsmError;
+use crate::notes::{GraphConfig, GraphDepth, NotesEngine};
+use actix_web::{delete, get, post, put, web, HttpRequest, HttpResponse, Responder};
+use serde::Deserialize;
+use serde_json::json;
+
+/// Query parameters for `GET /notes`
+#[derive(Deserialize)]
+pub struct ListNotesQuery {
+    prefix: Option<String>,
+}
+
+/// Request body for `PUT /notes/{path}`
+#[derive(Deserialize)]
+pub struct PutNoteBody {
+    content: String,
+}
+
+/// Query parameters for `GET /notes/{path}/graph`
+#[derive(Deserialize)]
+pub struct GraphQuery {
+    depth: Option<usize>,
+    max_nodes: Option<usize>,
+    tag_filter: Option<String>,
+}
+
+/// Query parameters for `GET /tags/{tag}/notes`
+#[derive(Deserialize)]
+pub struct TagNotesQuery {
+    cursor: Option<String>,
+    limit: Option<usize>,
+}
+
+/// Request body for `POST /notes/{path}/rename`
+#[derive(Deserialize)]
+pub struct RenameBody {
+    new_path: String,
+}
+
+// ── Handlers ────────────────────────────────────────────────────────────────
+
+/// `GET /notes` — list all notes with optional prefix filter.
+#[get("")]
+async fn list_notes(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    query: web::Query<ListNotesQuery>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    match engine.list_notes(query.prefix.as_deref()) {
+        Ok(notes) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "notes": notes })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to list notes: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /notes/{path}` — get a single note.
+#[get("/{path}")]
+async fn get_note(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.get_note(&note_path) {
+        Ok(Some(content)) => {
+            // Parse to return rich data
+            let parsed = crate::notes::parse_note(&content);
+            let backlinks = engine.get_backlinks(&note_path).unwrap_or_default();
+            let forward = engine.get_forward_links(&note_path).unwrap_or_default();
+
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .json(json!({
+                    "path": note_path,
+                    "content": content,
+                    "frontmatter": parsed.frontmatter,
+                    "links": forward,
+                    "backlinks": backlinks,
+                    "tags": parsed.inline_tags,
+                }))
+        }
+        Ok(None) => HttpResponse::NotFound()
+            .content_type("application/json")
+            .json(json!({ "error": "note not found" })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get note: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `PUT /notes/{path}` — create or update a note.
+#[put("/{path}")]
+async fn put_note(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    body: web::Json<PutNoteBody>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Write) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.put_note(&note_path, &body.content) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok", "path": note_path })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to put note: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `DELETE /notes/{path}` — delete a note.
+#[delete("/{path}")]
+async fn delete_note(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Delete) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.delete_note(&note_path) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok" })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to delete note: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `POST /notes/{path}/rename` — rename a note.
+#[post("/{path}/rename")]
+async fn rename_note(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    body: web::Json<RenameBody>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Write) {
+        return e;
+    }
+    let old_path = path.into_inner();
+    match engine.rename_note(&old_path, &body.new_path) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "status": "ok", "old_path": old_path, "new_path": body.new_path })),
+        Err(LsmError::InvalidArgument(msg)) => HttpResponse::NotFound()
+            .content_type("application/json")
+            .json(json!({ "error": msg })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to rename note: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /notes/{path}/backlinks` — list notes linking TO this note.
+#[get("/{path}/backlinks")]
+async fn get_backlinks(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.get_backlinks(&note_path) {
+        Ok(links) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "backlinks": links })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get backlinks: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /notes/{path}/links` — list notes linked FROM this note.
+#[get("/{path}/links")]
+async fn get_forward_links(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let note_path = path.into_inner();
+    match engine.get_forward_links(&note_path) {
+        Ok(links) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({ "links": links })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get forward links: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /notes/{path}/graph` — graph view data.
+#[get("/{path}/graph")]
+async fn get_graph(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    query: web::Query<GraphQuery>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let note_path = path.into_inner();
+
+    // Build graph config from query params
+    let depth = match query.depth.unwrap_or(1) {
+        0 => GraphDepth::Direct,
+        1 => GraphDepth::Direct,
+        2 => GraphDepth::Extended,
+        _ => GraphDepth::Deep,
+    };
+    let max_nodes = query.max_nodes.unwrap_or(500).min(500);
+    let config = GraphConfig {
+        depth,
+        max_nodes,
+        tag_filter: query.tag_filter.clone(),
+        include_tags: true,
+        include_isolated: false,
+    };
+
+    match engine.build_graph(&note_path, &config) {
+        Ok(graph_data) => HttpResponse::Ok()
+            .content_type("application/json")
+            .json(json!({
+                "root": graph_data.root,
+                "nodes": graph_data.nodes,
+                "edges": graph_data.edges,
+            })),
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to build graph: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /tags` — list all tags.
+#[get("/tags")]
+async fn list_tags(req: HttpRequest, engine: web::Data<NotesEngine>) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    match engine.list_tags() {
+        Ok(tags) => {
+            let tags_json: Vec<serde_json::Value> = tags
+                .into_iter()
+                .map(|(name, count)| json!({ "tag": name, "count": count }))
+                .collect();
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .json(json!({ "tags": tags_json }))
+        }
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to list tags: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+/// `GET /tags/{tag}/notes` — list notes with a specific tag.
+#[get("/tags/{tag}/notes")]
+async fn get_notes_by_tag(
+    req: HttpRequest,
+    engine: web::Data<NotesEngine>,
+    path: web::Path<String>,
+    query: web::Query<TagNotesQuery>,
+) -> impl Responder {
+    if let Err(e) = crate::api::require_permission(&req, crate::api::Permission::Read) {
+        return e;
+    }
+    let tag = path.into_inner();
+    match engine.search_by_tag(&tag, query.cursor.as_deref(), query.limit.unwrap_or(50)) {
+        Ok((notes, next_cursor)) => {
+            HttpResponse::Ok()
+                .content_type("application/json")
+                .json(json!({
+                    "tag": tag,
+                    "notes": notes,
+                    "cursor": next_cursor,
+                }))
+        }
+        Err(e) => {
+            tracing::error!(target: "apexstore::api::notes", "Failed to get notes by tag: {:?}", e);
+            HttpResponse::InternalServerError()
+                .content_type("application/json")
+                .json(json!({ "error": "internal server error" }))
+        }
+    }
+}
+
+// ── Route configuration ─────────────────────────────────────────────────────
+
+/// Register all notes API routes under `/notes` and `/tags`.
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/notes")
+            .service(list_notes)
+            .service(get_note)
+            .service(put_note)
+            .service(delete_note)
+            .service(rename_note)
+            .service(get_backlinks)
+            .service(get_forward_links)
+            .service(get_graph),
+    )
+    .service(list_tags)
+    .service(get_notes_by_tag);
+}

--- a/src/api/sync.rs
+++ b/src/api/sync.rs
@@ -1,0 +1,211 @@
+//! Real-time sync via WebSocket with CRDT-based conflict resolution.
+//!
+//! Provides a WebSocket endpoint at `/ws/sync` for bidirectional sync.
+//! Uses the existing CRDT engine for last-writer-wins conflict resolution.
+
+use actix_web::{get, web, HttpRequest, HttpResponse};
+use actix_ws::Message;
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+
+/// A change entry in the sync protocol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncChange {
+    pub key: String,
+    pub value: String,
+    pub timestamp: u64,
+    pub device_id: String,
+}
+
+/// Message sent from client to server.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum ClientMessage {
+    #[serde(rename = "sync_push")]
+    SyncPush {
+        changes: Vec<SyncChange>,
+        last_ack: u64,
+    },
+    #[serde(rename = "sync_ack")]
+    SyncAck { ack_timestamp: u64 },
+    #[serde(rename = "subscribe")]
+    Subscribe { note_path: String },
+}
+
+/// Message sent from server to client.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum ServerMessage {
+    #[serde(rename = "sync_ack")]
+    SyncAck {
+        ack_timestamp: u64,
+        changes: Vec<SyncChange>,
+    },
+    #[serde(rename = "sync_push")]
+    SyncPush { changes: Vec<SyncChange> },
+    #[serde(rename = "error")]
+    Error { message: String },
+}
+
+/// Manages connected WebSocket clients and CRDT state.
+pub struct SyncManager {
+    /// Connected clients (note_path -> broadcast channel).
+    clients: Mutex<Vec<tokio::sync::mpsc::UnboundedSender<String>>>,
+    /// CRDT engine for conflict resolution.
+    crdt: Mutex<crate::infra::crdt::CrdtEngine>,
+}
+
+impl SyncManager {
+    pub fn new() -> Self {
+        Self {
+            clients: Mutex::new(Vec::new()),
+            crdt: Mutex::new(crate::infra::crdt::CrdtEngine::new()),
+        }
+    }
+}
+
+impl Default for SyncManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncManager {
+    /// Register a new client connection.
+    pub fn register_client(&self, tx: tokio::sync::mpsc::UnboundedSender<String>) {
+        let mut clients = self.clients.lock().unwrap();
+        clients.push(tx);
+    }
+
+    /// Remove a disconnected client.
+    pub fn remove_client(&self, tx: &tokio::sync::mpsc::UnboundedSender<String>) {
+        let mut clients = self.clients.lock().unwrap();
+        clients.retain(|c| !c.same_channel(tx));
+    }
+
+    /// Broadcast a change to all connected clients.
+    pub fn broadcast(&self, change: &SyncChange) {
+        let msg = serde_json::to_string(&ServerMessage::SyncPush {
+            changes: vec![change.clone()],
+        })
+        .unwrap_or_default();
+        let mut clients = self.clients.lock().unwrap();
+        clients.retain(|c| c.send(msg.clone()).is_ok());
+    }
+
+    /// Merge a change into the CRDT engine and persist to storage.
+    pub fn apply_change(&self, change: &SyncChange, engine: &crate::LsmEngine, cf: &str) {
+        let mut crdt = self.crdt.lock().unwrap();
+        crdt.merge(
+            change.key.as_bytes().to_vec(),
+            change.value.as_bytes().to_vec(),
+            change.timestamp,
+        );
+
+        // Persist to LSM engine
+        let _ = engine.put_cf(
+            cf,
+            change.key.as_bytes().to_vec(),
+            change.value.as_bytes().to_vec(),
+        );
+
+        // Broadcast to other clients
+        self.broadcast(change);
+    }
+
+    /// Get pending changes since a given timestamp.
+    pub fn get_changes_since(&self, since: u64) -> Vec<SyncChange> {
+        let crdt = self.crdt.lock().unwrap();
+        crdt.get_all_entries()
+            .into_iter()
+            .filter(|e| e.timestamp > since)
+            .map(|e| SyncChange {
+                key: String::from_utf8_lossy(&e.key).to_string(),
+                value: String::from_utf8_lossy(&e.value).to_string(),
+                timestamp: e.timestamp,
+                device_id: "server".to_string(),
+            })
+            .collect()
+    }
+}
+
+/// WebSocket handler at `/ws/sync`.
+#[get("/ws/sync")]
+pub async fn sync_handler(
+    req: HttpRequest,
+    body: web::Payload,
+    sync_manager: web::Data<SyncManager>,
+    engine: web::Data<crate::LsmEngine>,
+) -> Result<HttpResponse, actix_web::Error> {
+    let (response, mut session, mut msg_stream) = actix_ws::handle(&req, body)?;
+
+    // Create a channel for sending messages to this client
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    sync_manager.register_client(tx.clone());
+
+    // Clone Data references for the task
+    let sync_mgr = sync_manager.clone();
+    let engine_data = engine.clone();
+
+    // Single task handling both inbound and outbound messages
+    actix_rt::spawn(async move {
+        loop {
+            tokio::select! {
+                // Outbound: forward messages from channel to WebSocket
+                Some(msg) = rx.recv() => {
+                    if session.text(msg).await.is_err() {
+                        break;
+                    }
+                }
+                // Inbound: handle incoming WebSocket messages
+                Some(Ok(msg)) = msg_stream.recv() => {
+                    match msg {
+                        Message::Text(text) => {
+                            if let Ok(client_msg) = serde_json::from_str::<ClientMessage>(&text) {
+                                match client_msg {
+                                    ClientMessage::SyncPush { changes, last_ack } => {
+                                        for change in &changes {
+                                            sync_mgr.apply_change(change, &engine_data, "default");
+                                        }
+                                        let pending = sync_mgr.get_changes_since(last_ack);
+                                        let ack = ServerMessage::SyncAck {
+                                            ack_timestamp: changes
+                                                .iter()
+                                                .map(|c| c.timestamp)
+                                                .max()
+                                                .unwrap_or(last_ack),
+                                            changes: pending,
+                                        };
+                                        if let Ok(json) = serde_json::to_string(&ack) {
+                                            let _ = tx.send(json);
+                                        }
+                                    }
+                                    ClientMessage::SyncAck { ack_timestamp: _ } => {}
+                                    ClientMessage::Subscribe { note_path: _ } => {}
+                                }
+                            }
+                        }
+                        Message::Ping(bytes) => {
+                            let _ = session.pong(&bytes).await;
+                        }
+                        Message::Close(_) => {
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                else => {
+                    break;
+                }
+            }
+        }
+        sync_mgr.remove_client(&tx);
+    });
+
+    Ok(response)
+}
+
+/// Get all current CRDT entries (for REST API).
+pub fn get_all_entries(sync_manager: &SyncManager) -> Vec<crate::infra::crdt::CrdtEntry> {
+    sync_manager.crdt.lock().unwrap().get_all_entries()
+}

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -107,7 +107,15 @@ async fn main() -> std::io::Result<()> {
 
     println!("✓ Engine initialized successfully!\n");
 
-    apexstore::api::start_server(Arc::new(engine), server_config)
+    let engine = Arc::new(engine);
+
+    // Register default frontmatter schema on startup
+    {
+        let note_engine = apexstore::notes::NoteEngine::new(engine.clone());
+        let _ = apexstore::notes::validate::register_default_schema(&note_engine);
+    }
+
+    apexstore::api::start_server(engine, server_config)
         .await
         .map_err(|e: io::Error| e)
 }

--- a/src/infra/crdt.rs
+++ b/src/infra/crdt.rs
@@ -78,6 +78,18 @@ impl CrdtEngine {
         self.state.is_empty()
     }
 
+    /// Return all entries currently tracked by the CRDT engine.
+    pub fn get_all_entries(&self) -> Vec<CrdtEntry> {
+        self.state
+            .iter()
+            .map(|(key, (value, timestamp))| CrdtEntry {
+                key: key.clone(),
+                value: value.clone(),
+                timestamp: *timestamp,
+            })
+            .collect()
+    }
+
     /// Clear all tracked state.
     pub fn clear(&mut self) {
         self.state.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod core;
 pub mod features;
 pub mod infra;
+pub mod notes;
 pub mod storage;
 
 // Re-exports for convenience and backward compatibility

--- a/src/notes/graph.rs
+++ b/src/notes/graph.rs
@@ -133,7 +133,8 @@ impl NoteGraph {
             }
 
             // Get forward links (notes this note points TO)
-            let forward_links = crate::notes::index::NoteIndex::get_forward_links(engine, cf, &current_note)?;
+            let forward_links =
+                crate::notes::index::NoteIndex::get_forward_links(engine, cf, &current_note)?;
             for target in &forward_links {
                 if nodes.len() >= config.max_nodes {
                     break;
@@ -147,9 +148,11 @@ impl NoteGraph {
                 });
 
                 // Update node connection count
-                nodes.entry(current_note.clone())
+                nodes
+                    .entry(current_note.clone())
                     .and_modify(|n| n.size = n.size.saturating_add(1));
-                nodes.entry(target.clone())
+                nodes
+                    .entry(target.clone())
                     .and_modify(|n| n.size = n.size.saturating_add(1));
 
                 if !visited.contains(target) {
@@ -171,7 +174,8 @@ impl NoteGraph {
             }
 
             // Get backlinks (notes that point TO this note)
-            let backlinks = crate::notes::index::NoteIndex::get_backlinks(engine, cf, &current_note)?;
+            let backlinks =
+                crate::notes::index::NoteIndex::get_backlinks(engine, cf, &current_note)?;
             for source in &backlinks {
                 if nodes.len() >= config.max_nodes {
                     break;
@@ -185,9 +189,11 @@ impl NoteGraph {
                 });
 
                 // Update node connection count
-                nodes.entry(current_note.clone())
+                nodes
+                    .entry(current_note.clone())
                     .and_modify(|n| n.size = n.size.saturating_add(1));
-                nodes.entry(source.clone())
+                nodes
+                    .entry(source.clone())
                     .and_modify(|n| n.size = n.size.saturating_add(1));
 
                 if !visited.contains(source) {
@@ -254,12 +260,8 @@ impl NoteGraph {
     /// Generate a human-readable label for a note path.
     fn note_label(path: &str) -> String {
         // Get the last component of the path (filename without extension)
-        let name = path
-            .split('/')
-            .next_back()
-            .unwrap_or(path);
-        name.trim_end_matches(".md")
-            .replace(['-', '_'], " ")
+        let name = path.split('/').next_back().unwrap_or(path);
+        name.trim_end_matches(".md").replace(['-', '_'], " ")
     }
 
     /// Check if a note has a specific tag (uses prefix scan on tag index).
@@ -320,11 +322,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut config = LsmConfig::default();
         config.core.dir_path = dir.path().to_path_buf();
-        crate::core::engine::Engine::new_from_config(
-            &config,
-            GlobalBlockCache::new(10, 4096),
-        )
-        .unwrap()
+        crate::core::engine::Engine::new_from_config(&config, GlobalBlockCache::new(10, 4096))
+            .unwrap()
     }
 
     #[test]

--- a/src/notes/graph.rs
+++ b/src/notes/graph.rs
@@ -1,0 +1,462 @@
+//! Note graph assembly — builds graph representations of note connections
+//! for visualization in the frontend graph view.
+//!
+//! The graph is returned as a JSON-serializable structure compatible with
+//! D3.js force layout and vis.js.
+
+use crate::infra::error::Result;
+use crate::storage::cache::Cache;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// A node in the note graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphNode {
+    /// Unique identifier for the node (note path).
+    pub id: String,
+    /// Display label for the node.
+    pub label: String,
+    /// Optional grouping/tag for color-coding.
+    pub group: Option<String>,
+    /// Node size (proportional to connection count).
+    pub size: usize,
+}
+
+/// An edge connecting two nodes in the graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphEdge {
+    /// Source node ID.
+    pub source: String,
+    /// Target node ID.
+    pub target: String,
+    /// Edge weight (always 1 for wikilinks, can be higher for multiple links).
+    pub weight: usize,
+}
+
+/// The complete graph structure, serializable to JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphData {
+    /// All nodes in the graph.
+    pub nodes: Vec<GraphNode>,
+    /// All edges connecting nodes.
+    pub edges: Vec<GraphEdge>,
+    /// The root/center node ID (the note being viewed).
+    pub root: String,
+}
+
+/// Graph traversal depth.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum GraphDepth {
+    /// Only direct neighbors (1 hop).
+    Direct = 1,
+    /// Neighbors of neighbors (2 hops).
+    Extended = 2,
+    /// Maximum depth (3 hops).
+    Deep = 3,
+}
+
+impl GraphDepth {
+    pub fn from_usize(depth: usize) -> Self {
+        match depth {
+            0 | 1 => GraphDepth::Direct,
+            2 => GraphDepth::Extended,
+            _ => GraphDepth::Deep,
+        }
+    }
+}
+
+/// Configuration for graph assembly.
+#[derive(Debug, Clone)]
+pub struct GraphConfig {
+    /// Maximum traversal depth.
+    pub depth: GraphDepth,
+    /// Whether to include tag-based grouping.
+    pub include_tags: bool,
+    /// Maximum number of nodes to include.
+    pub max_nodes: usize,
+    /// Optional tag filter — only include notes with this tag.
+    pub tag_filter: Option<String>,
+    /// Whether to include isolated nodes (notes with no connections).
+    pub include_isolated: bool,
+}
+
+impl Default for GraphConfig {
+    fn default() -> Self {
+        Self {
+            depth: GraphDepth::Direct,
+            include_tags: true,
+            max_nodes: 500,
+            tag_filter: None,
+            include_isolated: false,
+        }
+    }
+}
+
+/// The note graph engine — assembles graph data from note indexes.
+pub struct NoteGraph;
+
+impl NoteGraph {
+    /// Build a graph centered on a specific note.
+    ///
+    /// Traverses links and backlinks up to `config.depth` hops and returns
+    /// a `GraphData` structure with nodes and edges.
+    pub fn build_graph<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        center_note: &str,
+        config: &GraphConfig,
+    ) -> Result<GraphData> {
+        let mut nodes: HashMap<String, GraphNode> = HashMap::new();
+        let mut edges: Vec<GraphEdge> = Vec::new();
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<(String, usize)> = VecDeque::new();
+
+        // Add the center node
+        let center_id = center_note.to_string();
+        let center_label = Self::note_label(center_note);
+        nodes.insert(
+            center_id.clone(),
+            GraphNode {
+                id: center_id.clone(),
+                label: center_label,
+                group: None,
+                size: 1,
+            },
+        );
+        visited.insert(center_id.clone());
+        queue.push_back((center_id.clone(), 0));
+
+        // BFS traversal
+        while let Some((current_note, current_depth)) = queue.pop_front() {
+            if current_depth >= config.depth as usize {
+                continue;
+            }
+
+            // Get forward links (notes this note points TO)
+            let forward_links = crate::notes::index::NoteIndex::get_forward_links(engine, cf, &current_note)?;
+            for target in &forward_links {
+                if nodes.len() >= config.max_nodes {
+                    break;
+                }
+
+                // Add edge
+                edges.push(GraphEdge {
+                    source: current_note.clone(),
+                    target: target.clone(),
+                    weight: 1,
+                });
+
+                // Update node connection count
+                nodes.entry(current_note.clone())
+                    .and_modify(|n| n.size = n.size.saturating_add(1));
+                nodes.entry(target.clone())
+                    .and_modify(|n| n.size = n.size.saturating_add(1));
+
+                if !visited.contains(target) {
+                    visited.insert(target.clone());
+                    let label = Self::note_label(target);
+                    nodes.insert(
+                        target.clone(),
+                        GraphNode {
+                            id: target.clone(),
+                            label,
+                            group: None,
+                            size: 1,
+                        },
+                    );
+                    if current_depth + 1 < config.depth as usize {
+                        queue.push_back((target.clone(), current_depth + 1));
+                    }
+                }
+            }
+
+            // Get backlinks (notes that point TO this note)
+            let backlinks = crate::notes::index::NoteIndex::get_backlinks(engine, cf, &current_note)?;
+            for source in &backlinks {
+                if nodes.len() >= config.max_nodes {
+                    break;
+                }
+
+                // Add edge
+                edges.push(GraphEdge {
+                    source: source.clone(),
+                    target: current_note.clone(),
+                    weight: 1,
+                });
+
+                // Update node connection count
+                nodes.entry(current_note.clone())
+                    .and_modify(|n| n.size = n.size.saturating_add(1));
+                nodes.entry(source.clone())
+                    .and_modify(|n| n.size = n.size.saturating_add(1));
+
+                if !visited.contains(source) {
+                    visited.insert(source.clone());
+                    let label = Self::note_label(source);
+                    nodes.insert(
+                        source.clone(),
+                        GraphNode {
+                            id: source.clone(),
+                            label,
+                            group: None,
+                            size: 1,
+                        },
+                    );
+                    if current_depth + 1 < config.depth as usize {
+                        queue.push_back((source.clone(), current_depth + 1));
+                    }
+                }
+            }
+        }
+
+        // Apply tag filter if specified
+        let mut nodes = if let Some(ref filter_tag) = config.tag_filter {
+            let filtered: HashMap<String, GraphNode> = nodes
+                .into_iter()
+                .filter(|(id, _)| {
+                    // Check if note has the tag (simplified: tag prefix scan)
+                    Self::note_has_tag(engine, cf, id, filter_tag).unwrap_or(false)
+                })
+                .collect();
+            filtered
+        } else {
+            nodes
+        };
+
+        // Filter edges to only include nodes that exist
+        edges.retain(|e| nodes.contains_key(&e.source) && nodes.contains_key(&e.target));
+
+        // Deduplicate edges (same source+target may appear from both forward and backlink traversal)
+        let mut seen_edges: HashSet<(String, String)> = HashSet::new();
+        edges.retain(|e| {
+            let key = if e.source < e.target {
+                (e.source.clone(), e.target.clone())
+            } else {
+                (e.target.clone(), e.source.clone())
+            };
+            seen_edges.insert(key)
+        });
+
+        // Apply tag-based grouping if enabled
+        if config.include_tags {
+            Self::apply_tag_groups(engine, cf, &mut nodes)?;
+        }
+
+        let node_list: Vec<GraphNode> = nodes.into_values().collect();
+
+        Ok(GraphData {
+            nodes: node_list,
+            edges,
+            root: center_note.to_string(),
+        })
+    }
+
+    /// Generate a human-readable label for a note path.
+    fn note_label(path: &str) -> String {
+        // Get the last component of the path (filename without extension)
+        let name = path
+            .split('/')
+            .next_back()
+            .unwrap_or(path);
+        name.trim_end_matches(".md")
+            .replace(['-', '_'], " ")
+    }
+
+    /// Check if a note has a specific tag (uses prefix scan on tag index).
+    fn note_has_tag<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        note_path: &str,
+        tag: &str,
+    ) -> Result<bool> {
+        // Scan tag index for this note
+        let tag_key = format!("tag:{}", tag);
+        match engine.get_cf(cf, tag_key.into_bytes())? {
+            Some(bytes) => {
+                let value = String::from_utf8_lossy(&bytes);
+                let notes: Vec<String> = serde_json::from_str(&value).unwrap_or_default();
+                Ok(notes.contains(&note_path.to_string()))
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Apply tag-based grouping to nodes.
+    fn apply_tag_groups<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        nodes: &mut HashMap<String, GraphNode>,
+    ) -> Result<()> {
+        // For each node, find its primary tag (first tag in its tag index)
+        for (id, node) in nodes.iter_mut() {
+            // Try to find a tag for this note by scanning the tag store
+            // We use a simple heuristic: check most common tags
+            let common_tags = ["important", "project", "reference", "archive", "personal"];
+            for tag in &common_tags {
+                let tag_key = format!("tag:{}", tag);
+                if let Ok(Some(bytes)) = engine.get_cf(cf, tag_key.into_bytes()) {
+                    let value = String::from_utf8_lossy(&bytes);
+                    let notes: Vec<String> = serde_json::from_str(&value).unwrap_or_default();
+                    if notes.contains(id) {
+                        node.group = Some(tag.to_string());
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::LsmConfig;
+    use crate::notes::index::NoteIndex;
+    use crate::storage::cache::GlobalBlockCache;
+    use std::sync::Arc;
+
+    fn create_test_engine() -> crate::core::engine::Engine<Arc<GlobalBlockCache>> {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = LsmConfig::default();
+        config.core.dir_path = dir.path().to_path_buf();
+        crate::core::engine::Engine::new_from_config(
+            &config,
+            GlobalBlockCache::new(10, 4096),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_basic_graph() {
+        let engine = create_test_engine();
+
+        // Set up: A → B, A → C
+        let targets_a = vec!["note-b".to_string(), "note-c".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-a", &targets_a).unwrap();
+
+        let config = GraphConfig::default();
+        let graph = NoteGraph::build_graph(&engine, "default", "note-a", &config).unwrap();
+
+        assert_eq!(graph.root, "note-a");
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(graph.edges.len(), 2);
+
+        // Root should have size = connections + 1
+        let root_node = graph.nodes.iter().find(|n| n.id == "note-a").unwrap();
+        assert!(root_node.size >= 2);
+    }
+
+    #[test]
+    fn test_depth_traversal() {
+        let engine = create_test_engine();
+
+        // A → B → C
+        NoteIndex::index_links(&engine, "default", "note-a", &["note-b".to_string()]).unwrap();
+        NoteIndex::index_links(&engine, "default", "note-b", &["note-c".to_string()]).unwrap();
+
+        // Depth 1: only A and B
+        let config = GraphConfig {
+            depth: GraphDepth::Direct,
+            ..Default::default()
+        };
+        let graph = NoteGraph::build_graph(&engine, "default", "note-a", &config).unwrap();
+        assert_eq!(graph.nodes.len(), 2);
+        assert!(graph.nodes.iter().any(|n| n.id == "note-a"));
+        assert!(graph.nodes.iter().any(|n| n.id == "note-b"));
+
+        // Depth 2: A, B, and C
+        let config = GraphConfig {
+            depth: GraphDepth::Extended,
+            ..Default::default()
+        };
+        let graph = NoteGraph::build_graph(&engine, "default", "note-a", &config).unwrap();
+        assert_eq!(graph.nodes.len(), 3);
+        assert!(graph.nodes.iter().any(|n| n.id == "note-c"));
+    }
+
+    #[test]
+    fn test_graph_with_backlinks() {
+        let engine = create_test_engine();
+
+        // X → Y, Z → Y (Y has 2 backlinks)
+        NoteIndex::index_links(&engine, "default", "note-x", &["note-y".to_string()]).unwrap();
+        NoteIndex::index_links(&engine, "default", "note-z", &["note-y".to_string()]).unwrap();
+
+        let config = GraphConfig::default();
+        let graph = NoteGraph::build_graph(&engine, "default", "note-y", &config).unwrap();
+
+        // Y, X, Z should all be in the graph
+        assert_eq!(graph.nodes.len(), 3);
+        assert_eq!(graph.edges.len(), 2);
+    }
+
+    #[test]
+    fn test_graph_max_nodes() {
+        let engine = create_test_engine();
+
+        // Connect A to many notes
+        let many_targets: Vec<String> = (0..20).map(|i| format!("note-{}", i)).collect();
+        NoteIndex::index_links(&engine, "default", "note-a", &many_targets).unwrap();
+
+        let config = GraphConfig {
+            max_nodes: 10,
+            ..Default::default()
+        };
+        let graph = NoteGraph::build_graph(&engine, "default", "note-a", &config).unwrap();
+
+        assert!(graph.nodes.len() <= 10);
+    }
+
+    #[test]
+    fn test_graph_isolated_note() {
+        let engine = create_test_engine();
+
+        // Note with no links
+        let config = GraphConfig::default();
+        let graph = NoteGraph::build_graph(&engine, "default", "lonely-note", &config).unwrap();
+
+        assert_eq!(graph.nodes.len(), 1);
+        assert_eq!(graph.nodes[0].id, "lonely-note");
+        assert!(graph.edges.is_empty());
+    }
+
+    #[test]
+    fn test_graph_label_formatting() {
+        assert_eq!(NoteGraph::note_label("my-note.md"), "my note");
+        assert_eq!(NoteGraph::note_label("path/to/feature-x.md"), "feature x");
+        assert_eq!(NoteGraph::note_label("simple"), "simple");
+    }
+
+    #[test]
+    fn test_graph_serialization() {
+        let engine = create_test_engine();
+
+        NoteIndex::index_links(&engine, "default", "note-a", &["note-b".to_string()]).unwrap();
+
+        let config = GraphConfig::default();
+        let graph = NoteGraph::build_graph(&engine, "default", "note-a", &config).unwrap();
+
+        // Must serialize to valid JSON
+        let json = serde_json::to_string(&graph).unwrap();
+        assert!(json.contains("nodes"));
+        assert!(json.contains("edges"));
+        assert!(json.contains("root"));
+    }
+
+    #[test]
+    fn test_edge_dedup() {
+        let engine = create_test_engine();
+
+        // A → B (forward link)
+        NoteIndex::index_links(&engine, "default", "note-a", &["note-b".to_string()]).unwrap();
+        // B → A (backlink — creates the same edge A-B)
+        NoteIndex::index_links(&engine, "default", "note-b", &["note-a".to_string()]).unwrap();
+
+        let config = GraphConfig::default();
+        let graph = NoteGraph::build_graph(&engine, "default", "note-a", &config).unwrap();
+
+        // Should only have 1 edge (A-B) despite both forward and backlink
+        assert_eq!(graph.edges.len(), 1);
+    }
+}

--- a/src/notes/index.rs
+++ b/src/notes/index.rs
@@ -168,8 +168,7 @@ impl NoteIndex {
         let mut sources: Vec<String> = match engine.get_cf(cf, key.as_bytes())? {
             Some(bytes) => {
                 let val = String::from_utf8_lossy(&bytes);
-                serde_json::from_str(&val)
-                    .unwrap_or_default()
+                serde_json::from_str(&val).unwrap_or_default()
             }
             None => Vec::new(),
         };
@@ -195,8 +194,7 @@ impl NoteIndex {
         let mut sources: Vec<String> = match engine.get_cf(cf, key.as_bytes())? {
             Some(bytes) => {
                 let val = String::from_utf8_lossy(&bytes);
-                serde_json::from_str(&val)
-                    .unwrap_or_default()
+                serde_json::from_str(&val).unwrap_or_default()
             }
             None => return Ok(()),
         };
@@ -216,17 +214,9 @@ impl NoteIndex {
 
     /// Compute the diff between old and new link targets.
     fn compute_link_diff(old: &[String], new: &[String]) -> LinkDiff {
-        let added: Vec<String> = new
-            .iter()
-            .filter(|t| !old.contains(t))
-            .cloned()
-            .collect();
+        let added: Vec<String> = new.iter().filter(|t| !old.contains(t)).cloned().collect();
 
-        let removed: Vec<String> = old
-            .iter()
-            .filter(|t| !new.contains(t))
-            .cloned()
-            .collect();
+        let removed: Vec<String> = old.iter().filter(|t| !new.contains(t)).cloned().collect();
 
         LinkDiff { added, removed }
     }
@@ -243,11 +233,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut config = LsmConfig::default();
         config.core.dir_path = dir.path().to_path_buf();
-        crate::core::engine::Engine::new_from_config(
-            &config,
-            GlobalBlockCache::new(10, 4096),
-        )
-        .unwrap()
+        crate::core::engine::Engine::new_from_config(&config, GlobalBlockCache::new(10, 4096))
+            .unwrap()
     }
 
     #[test]
@@ -255,8 +242,7 @@ mod tests {
         let engine = create_test_engine();
         let new_targets: Vec<String> = vec!["note-a".to_string(), "note-b".to_string()];
 
-        let diff = NoteIndex::index_links(&engine, "default", "source-note", &new_targets)
-            .unwrap();
+        let diff = NoteIndex::index_links(&engine, "default", "source-note", &new_targets).unwrap();
 
         assert_eq!(diff.added.len(), 2);
         assert!(diff.removed.is_empty());
@@ -375,8 +361,7 @@ mod tests {
     fn test_empty_targets() {
         let engine = create_test_engine();
 
-        let diff = NoteIndex::index_links(&engine, "default", "empty-note", &[])
-            .unwrap();
+        let diff = NoteIndex::index_links(&engine, "default", "empty-note", &[]).unwrap();
         assert!(diff.added.is_empty());
         assert!(diff.removed.is_empty());
 

--- a/src/notes/index.rs
+++ b/src/notes/index.rs
@@ -1,0 +1,399 @@
+//! Forward-link and backlink index management for notes.
+//!
+//! Maintains bidirectional link indexes in the LSM store:
+//!
+//! - `link:{target_note}` → JSON array of source note paths that link TO target
+//! - `backlink:{source_note}` → JSON array of target note paths linked FROM source
+
+use crate::infra::error::{LsmError, Result};
+use crate::storage::cache::Cache;
+
+/// Key prefix for the forward-link index.
+const LINK_PREFIX: &str = "link:";
+/// Key prefix for the backlink index.
+const BACKLINK_PREFIX: &str = "backlink:";
+
+/// The link index engine — manages bidirectional link indexes.
+///
+/// This does NOT own the engine; it takes a reference for each operation.
+/// `C` is the block cache type parameter of the LSM engine.
+pub struct NoteIndex;
+
+/// A diff of link changes for a single note update.
+pub struct LinkDiff {
+    /// Links that were added (new targets).
+    pub added: Vec<String>,
+    /// Links that were removed (old targets no longer present).
+    pub removed: Vec<String>,
+}
+
+impl NoteIndex {
+    /// Index the links for a note. Computes a diff between old and new links,
+    /// then atomically updates both `link:` and `backlink:` indexes.
+    ///
+    /// Parameters:
+    /// - `engine` — the LSM storage engine
+    /// - `cf` — column family to use for index storage (default: "default")
+    /// - `note_path` — the path of the note being indexed
+    /// - `new_targets` — the new set of link targets extracted from the note
+    pub fn index_links<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        note_path: &str,
+        new_targets: &[String],
+    ) -> Result<LinkDiff> {
+        let current_targets = Self::get_forward_links(engine, cf, note_path)?;
+        let diff = Self::compute_link_diff(&current_targets, new_targets);
+
+        // Remove old links
+        for target in &diff.removed {
+            Self::remove_from_link_index(engine, cf, target, note_path)?;
+        }
+
+        // Add new links
+        for target in &diff.added {
+            Self::add_to_link_index(engine, cf, target, note_path)?;
+        }
+
+        // Update the backlink index for this note (store current outbound targets)
+        let backlink_key = format!("{}{}", BACKLINK_PREFIX, note_path);
+        let value = serde_json::to_string(new_targets)
+            .map_err(|e| LsmError::InvalidArgument(format!("JSON serialization error: {}", e)))?;
+        engine.put_cf(cf, backlink_key.into_bytes(), value.into_bytes())?;
+
+        Ok(diff)
+    }
+
+    /// Remove all link indexes for a note (used when deleting or moving a note).
+    pub fn remove_note_links<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        note_path: &str,
+    ) -> Result<()> {
+        let targets = Self::get_forward_links(engine, cf, note_path)?;
+
+        // Remove this note from each target's link index
+        for target in &targets {
+            Self::remove_from_link_index(engine, cf, target, note_path)?;
+        }
+
+        // Delete the backlink index for this note
+        let backlink_key = format!("{}{}", BACKLINK_PREFIX, note_path);
+        engine.delete_cf(cf, backlink_key.into_bytes())?;
+
+        Ok(())
+    }
+
+    /// Get all notes that link TO the given note (backlinks).
+    pub fn get_backlinks<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        note_path: &str,
+    ) -> Result<Vec<String>> {
+        let key = format!("{}{}", LINK_PREFIX, note_path);
+        match engine.get_cf(cf, key.into_bytes())? {
+            Some(bytes) => {
+                let value = String::from_utf8_lossy(&bytes);
+                serde_json::from_str(&value)
+                    .map_err(|e| LsmError::InvalidArgument(format!("JSON parse error: {}", e)))
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Get all notes that the given note links TO (forward links).
+    pub fn get_forward_links<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        note_path: &str,
+    ) -> Result<Vec<String>> {
+        let key = format!("{}{}", BACKLINK_PREFIX, note_path);
+        match engine.get_cf(cf, key.into_bytes())? {
+            Some(bytes) => {
+                let value = String::from_utf8_lossy(&bytes);
+                serde_json::from_str(&value)
+                    .map_err(|e| LsmError::InvalidArgument(format!("JSON parse error: {}", e)))
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Rename a note and update all indexes accordingly.
+    ///
+    /// This is a higher-level operation that:
+    /// 1. Removes all link indexes for `old_path`
+    /// 2. Re-indexes links for `new_path`
+    /// 3. Updates all notes that linked to `old_path` to now point to `new_path`
+    pub fn rename_note<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        old_path: &str,
+        new_path: &str,
+        new_content: &[String],
+    ) -> Result<()> {
+        // Get all notes that linked to the old path
+        let backlinks = Self::get_backlinks(engine, cf, old_path)?;
+
+        // Remove old indexes
+        Self::remove_note_links(engine, cf, old_path)?;
+
+        // Update all notes that pointed to old_path -> now point to new_path
+        for source in &backlinks {
+            // Remove old_path from this source's link index
+            Self::remove_from_link_index(engine, cf, old_path, source)?;
+            // Add new_path to this source's link index
+            Self::add_to_link_index(engine, cf, new_path, source)?;
+        }
+
+        // Delete the old backlink entry for new_path (if it exists from a previous index)
+        let new_backlink_key = format!("{}{}", BACKLINK_PREFIX, new_path);
+        let _ = engine.delete_cf(cf, new_backlink_key.into_bytes());
+
+        // Index the new note links
+        Self::index_links(engine, cf, new_path, new_content)?;
+
+        Ok(())
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────
+
+    /// Add a source note to the link index for a target.
+    fn add_to_link_index<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        target: &str,
+        source: &str,
+    ) -> Result<()> {
+        let key = format!("{}{}", LINK_PREFIX, target);
+        let mut sources: Vec<String> = match engine.get_cf(cf, key.as_bytes())? {
+            Some(bytes) => {
+                let val = String::from_utf8_lossy(&bytes);
+                serde_json::from_str(&val)
+                    .unwrap_or_default()
+            }
+            None => Vec::new(),
+        };
+
+        if !sources.contains(&source.to_string()) {
+            sources.push(source.to_string());
+            let value = serde_json::to_string(&sources)
+                .map_err(|e| LsmError::InvalidArgument(format!("JSON error: {}", e)))?;
+            engine.put_cf(cf, key.into_bytes(), value.into_bytes())?;
+        }
+
+        Ok(())
+    }
+
+    /// Remove a source note from the link index for a target.
+    fn remove_from_link_index<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        target: &str,
+        source: &str,
+    ) -> Result<()> {
+        let key = format!("{}{}", LINK_PREFIX, target);
+        let mut sources: Vec<String> = match engine.get_cf(cf, key.as_bytes())? {
+            Some(bytes) => {
+                let val = String::from_utf8_lossy(&bytes);
+                serde_json::from_str(&val)
+                    .unwrap_or_default()
+            }
+            None => return Ok(()),
+        };
+
+        sources.retain(|s| s != source);
+
+        if sources.is_empty() {
+            engine.delete_cf(cf, key.into_bytes())?;
+        } else {
+            let value = serde_json::to_string(&sources)
+                .map_err(|e| LsmError::InvalidArgument(format!("JSON error: {}", e)))?;
+            engine.put_cf(cf, key.into_bytes(), value.into_bytes())?;
+        }
+
+        Ok(())
+    }
+
+    /// Compute the diff between old and new link targets.
+    fn compute_link_diff(old: &[String], new: &[String]) -> LinkDiff {
+        let added: Vec<String> = new
+            .iter()
+            .filter(|t| !old.contains(t))
+            .cloned()
+            .collect();
+
+        let removed: Vec<String> = old
+            .iter()
+            .filter(|t| !new.contains(t))
+            .cloned()
+            .collect();
+
+        LinkDiff { added, removed }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::LsmConfig;
+    use crate::storage::cache::GlobalBlockCache;
+    use std::sync::Arc;
+
+    fn create_test_engine() -> crate::core::engine::Engine<Arc<GlobalBlockCache>> {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = LsmConfig::default();
+        config.core.dir_path = dir.path().to_path_buf();
+        crate::core::engine::Engine::new_from_config(
+            &config,
+            GlobalBlockCache::new(10, 4096),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_index_links_empty() {
+        let engine = create_test_engine();
+        let new_targets: Vec<String> = vec!["note-a".to_string(), "note-b".to_string()];
+
+        let diff = NoteIndex::index_links(&engine, "default", "source-note", &new_targets)
+            .unwrap();
+
+        assert_eq!(diff.added.len(), 2);
+        assert!(diff.removed.is_empty());
+
+        // Verify backlinks from target perspective
+        let backlinks = NoteIndex::get_backlinks(&engine, "default", "note-a").unwrap();
+        assert_eq!(backlinks, vec!["source-note"]);
+
+        // Verify forward links from source perspective
+        let forward = NoteIndex::get_forward_links(&engine, "default", "source-note").unwrap();
+        assert_eq!(forward, vec!["note-a", "note-b"]);
+    }
+
+    #[test]
+    fn test_index_links_update() {
+        let engine = create_test_engine();
+
+        // First index: links to A and B
+        let targets1 = vec!["note-a".to_string(), "note-b".to_string()];
+        NoteIndex::index_links(&engine, "default", "source", &targets1).unwrap();
+
+        // Second index: links to B and C (A removed, C added)
+        let targets2 = vec!["note-b".to_string(), "note-c".to_string()];
+        let diff = NoteIndex::index_links(&engine, "default", "source", &targets2).unwrap();
+
+        assert_eq!(diff.added, vec!["note-c"]);
+        assert_eq!(diff.removed, vec!["note-a"]);
+
+        // A should no longer have source as backlink
+        let backlinks_a = NoteIndex::get_backlinks(&engine, "default", "note-a").unwrap();
+        assert!(backlinks_a.is_empty());
+
+        // B should still have source
+        let backlinks_b = NoteIndex::get_backlinks(&engine, "default", "note-b").unwrap();
+        assert_eq!(backlinks_b, vec!["source"]);
+
+        // C should now have source
+        let backlinks_c = NoteIndex::get_backlinks(&engine, "default", "note-c").unwrap();
+        assert_eq!(backlinks_c, vec!["source"]);
+    }
+
+    #[test]
+    fn test_remove_note_links() {
+        let engine = create_test_engine();
+
+        let targets = vec!["note-a".to_string(), "note-b".to_string()];
+        NoteIndex::index_links(&engine, "default", "source", &targets).unwrap();
+
+        NoteIndex::remove_note_links(&engine, "default", "source").unwrap();
+
+        // Backlinks should be cleaned up
+        let backlinks_a = NoteIndex::get_backlinks(&engine, "default", "note-a").unwrap();
+        assert!(backlinks_a.is_empty());
+
+        let forward = NoteIndex::get_forward_links(&engine, "default", "source").unwrap();
+        assert!(forward.is_empty());
+    }
+
+    #[test]
+    fn test_rename_note() {
+        let engine = create_test_engine();
+
+        // Note-X links to note-A and note-B
+        let targets_x = vec!["note-a".to_string(), "note-b".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-x", &targets_x).unwrap();
+
+        // Note-Y links to note-X
+        let targets_y = vec!["note-x".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-y", &targets_y).unwrap();
+
+        // Rename note-X to note-X-renamed
+        let new_content = vec!["note-a".to_string(), "note-c".to_string()];
+        NoteIndex::rename_note(&engine, "default", "note-x", "note-x-renamed", &new_content)
+            .unwrap();
+
+        // note-y should now link to note-x-renamed
+        let backlinks = NoteIndex::get_backlinks(&engine, "default", "note-x-renamed").unwrap();
+        assert!(backlinks.contains(&"note-y".to_string()));
+
+        // Old note-x should have no backlinks
+        let old_backlinks = NoteIndex::get_backlinks(&engine, "default", "note-x").unwrap();
+        assert!(old_backlinks.is_empty());
+    }
+
+    #[test]
+    fn test_self_link() {
+        let engine = create_test_engine();
+
+        // A note linking to itself should work without infinite loops
+        let targets = vec!["note-a".to_string(), "self".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-a", &targets).unwrap();
+
+        let backlinks = NoteIndex::get_backlinks(&engine, "default", "self").unwrap();
+        assert!(backlinks.contains(&"note-a".to_string()));
+    }
+
+    #[test]
+    fn test_circular_links() {
+        let engine = create_test_engine();
+
+        let targets_a = vec!["note-b".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-a", &targets_a).unwrap();
+
+        let targets_b = vec!["note-c".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-b", &targets_b).unwrap();
+
+        let targets_c = vec!["note-a".to_string()];
+        NoteIndex::index_links(&engine, "default", "note-c", &targets_c).unwrap();
+
+        // Circular: A→B→C→A — should not stack overflow or panic
+        let backlinks_a = NoteIndex::get_backlinks(&engine, "default", "note-a").unwrap();
+        assert_eq!(backlinks_a, vec!["note-c"]);
+    }
+
+    #[test]
+    fn test_empty_targets() {
+        let engine = create_test_engine();
+
+        let diff = NoteIndex::index_links(&engine, "default", "empty-note", &[])
+            .unwrap();
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+
+        let forward = NoteIndex::get_forward_links(&engine, "default", "empty-note").unwrap();
+        assert!(forward.is_empty());
+    }
+
+    #[test]
+    fn test_noop_update() {
+        let engine = create_test_engine();
+
+        let targets = vec!["a".to_string(), "b".to_string()];
+        NoteIndex::index_links(&engine, "default", "note", &targets).unwrap();
+
+        // Same targets — should be a no-op
+        let diff = NoteIndex::index_links(&engine, "default", "note", &targets).unwrap();
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+    }
+}

--- a/src/notes/mod.rs
+++ b/src/notes/mod.rs
@@ -131,6 +131,152 @@ impl<C: Cache> NoteEngine<C> {
         Ok(())
     }
 
+    /// Create or update a note and save a version snapshot.
+    /// Same as `put_note` but also records a version entry for history.
+    pub fn put_note_with_version(&self, path: &str, content: &str) -> Result<()> {
+        self.put_note(path, content)?;
+        self.save_version(path)
+    }
+
+    /// Save the current note content as a version entry.
+    fn save_version(&self, path: &str) -> Result<()> {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros();
+
+        let version_key = format!("__version:{}", path);
+        let version_entry_key = format!("__version_content:{}:{}", path, ts);
+
+        // Get current content
+        let content = self.get_note(path)?;
+        if let Some(content) = content {
+            // Store the versioned content
+            self.engine.put_cf(
+                &self.cf,
+                version_entry_key.into_bytes(),
+                content.into_bytes(),
+            )?;
+
+            // Update version metadata
+            let mut timestamps: Vec<u128> =
+                match self.engine.get_cf(&self.cf, version_key.as_bytes())? {
+                    Some(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+                    None => Vec::new(),
+                };
+            timestamps.push(ts);
+
+            // Trim to max 100 versions
+            while timestamps.len() > 100 {
+                let removed = timestamps.remove(0);
+                let old_key = format!("__version_content:{}:{}", path, removed);
+                let _ = self.engine.delete_cf(&self.cf, old_key.into_bytes());
+            }
+
+            let value = serde_json::to_vec(&timestamps).map_err(|e| {
+                crate::infra::error::LsmError::InvalidArgument(format!("JSON error: {}", e))
+            })?;
+            self.engine
+                .put_cf(&self.cf, version_key.into_bytes(), value)?;
+        }
+
+        Ok(())
+    }
+
+    /// Get the version history for a note (list of timestamps).
+    pub fn get_version_history(&self, path: &str) -> Result<Vec<u128>> {
+        let version_key = format!("__version:{}", path);
+        match self.engine.get_cf(&self.cf, version_key.as_bytes())? {
+            Some(bytes) => {
+                let timestamps: Vec<u128> = serde_json::from_slice(&bytes).unwrap_or_default();
+                Ok(timestamps)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Get the content of a note at a specific version timestamp.
+    pub fn get_note_at_version(&self, path: &str, timestamp: u128) -> Result<Option<String>> {
+        let version_entry_key = format!("__version_content:{}:{}", path, timestamp);
+        match self.engine.get_cf(&self.cf, version_entry_key.as_bytes())? {
+            Some(bytes) => {
+                let content = String::from_utf8_lossy(&bytes).to_string();
+                Ok(Some(content))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Remove a specific version from history.
+    pub fn remove_version(&self, path: &str, timestamp: u128) -> Result<bool> {
+        let version_key = format!("__version:{}", path);
+        let version_entry_key = format!("__version_content:{}:{}", path, timestamp);
+
+        // Remove the version content
+        self.engine
+            .delete_cf(&self.cf, version_entry_key.into_bytes())?;
+
+        // Update the version metadata
+        let mut timestamps: Vec<u128> =
+            match self.engine.get_cf(&self.cf, version_key.as_bytes())? {
+                Some(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+                None => return Ok(false),
+            };
+
+        let before = timestamps.len();
+        timestamps.retain(|t| *t != timestamp);
+
+        if timestamps.is_empty() {
+            self.engine.delete_cf(&self.cf, version_key.into_bytes())?;
+            Ok(before != 0)
+        } else {
+            let value = serde_json::to_vec(&timestamps).map_err(|e| {
+                crate::infra::error::LsmError::InvalidArgument(format!("JSON error: {}", e))
+            })?;
+            self.engine
+                .put_cf(&self.cf, version_key.into_bytes(), value)?;
+            Ok(true)
+        }
+    }
+
+    /// Restore a note to a previous version. Saves current version first, then
+    /// overwrites with the old version's content.
+    pub fn restore_version(&self, path: &str, timestamp: u128) -> Result<bool> {
+        // Get the old content
+        let content = self.get_note_at_version(path, timestamp)?;
+        match content {
+            Some(old_content) => {
+                // Save current as a version first
+                self.save_version(path)?;
+                // Write the old content as current
+                self.put_note(path, &old_content)?;
+                // Save another version entry for the restore
+                self.save_version(path)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Get all notes that were active at the given timestamp using TimeTravelEngine.
+    pub fn get_notes_at_timestamp(
+        &self,
+        time_travel: &crate::infra::time_travel::TimeTravelEngine,
+        timestamp: u128,
+    ) -> Result<Vec<(String, String)>> {
+        // Query all note: prefixed keys at the given timestamp
+        // Since TimeTravelEngine doesn't have prefix scan, we iterate known notes
+        let current_notes = self.list_notes(None)?;
+        let mut result = Vec::new();
+        for path in &current_notes {
+            let key = format!("note:{}", path);
+            if let Some(content) = time_travel.query_as_of(key.as_bytes(), timestamp) {
+                result.push((path.clone(), String::from_utf8_lossy(&content).to_string()));
+            }
+        }
+        Ok(result)
+    }
+
     /// Get a note's content by path.
     pub fn get_note(&self, path: &str) -> Result<Option<String>> {
         let note_key = format!("note:{}", path);

--- a/src/notes/mod.rs
+++ b/src/notes/mod.rs
@@ -40,6 +40,7 @@
 pub mod graph;
 pub mod index;
 pub mod parser;
+pub mod search;
 
 use crate::infra::error::Result;
 use crate::storage::cache::Cache;
@@ -51,6 +52,7 @@ pub use parser::{
     parse_frontmatter, parse_note, parse_tags, parse_wikilinks, Frontmatter, LinkType, ParsedNote,
     Wikilink,
 };
+pub use search::SearchHit;
 
 /// Type alias for the note engine using the default LSM engine with `GlobalBlockCache`.
 pub type NotesEngine = NoteEngine<std::sync::Arc<crate::storage::cache::GlobalBlockCache>>;
@@ -127,6 +129,9 @@ impl<C: Cache> NoteEngine<C> {
 
         // Update tag indexes
         self.index_tags(path, &parsed.inline_tags)?;
+
+        // Update full-text search index
+        let _ = search::FullTextSearch::index_note(&self.engine, &self.cf, path, content);
 
         Ok(())
     }
@@ -298,6 +303,9 @@ impl<C: Cache> NoteEngine<C> {
 
         // Remove tag indexes
         self.remove_note_tags(path)?;
+
+        // Remove full-text search index
+        let _ = search::FullTextSearch::remove_note(&self.engine, &self.cf, path);
 
         // Delete the note content
         self.engine.delete_cf(&self.cf, note_key.into_bytes())?;
@@ -510,6 +518,21 @@ impl<C: Cache> NoteEngine<C> {
     /// Get all notes that the given note links TO (outgoing links).
     pub fn get_forward_links(&self, note_path: &str) -> Result<Vec<String>> {
         NoteIndex::get_forward_links(&self.engine, &self.cf, note_path)
+    }
+
+    // ── Full-text search ────────────────────────────────────────────────
+
+    /// Search notes by content using full-text search.
+    pub fn search_notes(&self, query: &str, max_results: usize) -> Result<Vec<SearchHit>> {
+        search::FullTextSearch::search(&self.engine, &self.cf, query, max_results)
+    }
+
+    /// Re-index a specific note in the full-text search index.
+    pub fn reindex_note(&self, path: &str) -> Result<()> {
+        if let Some(content) = self.get_note(path)? {
+            search::FullTextSearch::index_note(&self.engine, &self.cf, path, &content)?;
+        }
+        Ok(())
     }
 
     // ── Graph ──────────────────────────────────────────────────────────

--- a/src/notes/mod.rs
+++ b/src/notes/mod.rs
@@ -41,6 +41,8 @@ pub mod graph;
 pub mod index;
 pub mod parser;
 pub mod search;
+pub mod template;
+pub mod validate;
 
 use crate::infra::error::Result;
 use crate::storage::cache::Cache;
@@ -53,6 +55,8 @@ pub use parser::{
     Wikilink,
 };
 pub use search::SearchHit;
+pub use template::{render_template, NoteTemplate};
+pub use validate::FrontmatterSchema;
 
 /// Type alias for the note engine using the default LSM engine with `GlobalBlockCache`.
 pub type NotesEngine = NoteEngine<std::sync::Arc<crate::storage::cache::GlobalBlockCache>>;

--- a/src/notes/mod.rs
+++ b/src/notes/mod.rs
@@ -1,0 +1,525 @@
+//! # Note Engine — Obsidian-like note-taking layer
+//!
+//! Provides a complete note-taking layer on top of the ApexStore LSM engine,
+//! with support for:
+//!
+//! - **Wikilinks** — `[[Note Name]]` parsing and bidirectional linking
+//! - **Tags** — `#tag` extraction and indexing
+//! - **Frontmatter** — YAML metadata parsing (title, aliases, dates, custom fields)
+//! - **Graph view** — Force-directed graph assembly for visualization
+//! - **Forward/Backlink indexes** — Automatic bidirectional link management
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────┐
+//! │                NoteEngine                    │
+//! │  (wraps LsmEngine + manages indexes)         │
+//! │                                              │
+//! │  ┌──────────┐  ┌─────────┐  ┌───────────┐   │
+//! │  │NoteParser│  │NoteIndex│  │NoteGraph   │   │
+//! │  │wikilinks │  │link:    │  │D3.js JSON  │   │
+//! │  │tags      │  │backlink:│  │traversal   │   │
+//! │  │frontmatter│ └─────────┘  └───────────┘   │
+//! │  └──────────┘                               │
+//! └──────────────────────────────────────────────┘
+//! ```
+//!
+//! # Storage Schema
+//!
+//! ```text
+//! cf "default":
+//!   note:/path/to/note.md        → Markdown content
+//!   link:{target_note}           → [source_notes...] (JSON array)
+//!   backlink:{source_note}       → [target_notes...] (JSON array)
+//!   tag:{tagname}                → [note_paths...] (JSON array)
+//!   __blob_meta:{name}           → Blob metadata (JSON)
+//!   __blob_chunk:{name}:{seq}    → Raw chunk data
+//! ```
+
+pub mod graph;
+pub mod index;
+pub mod parser;
+
+use crate::infra::error::Result;
+use crate::storage::cache::Cache;
+
+// Re-exports
+pub use graph::{GraphConfig, GraphData, GraphDepth, GraphEdge, GraphNode, NoteGraph};
+pub use index::NoteIndex;
+pub use parser::{
+    parse_frontmatter, parse_note, parse_tags, parse_wikilinks, Frontmatter, LinkType, ParsedNote,
+    Wikilink,
+};
+
+/// The high-level note engine that wraps the LSM storage engine and provides
+/// Obsidian-like note operations.
+///
+/// # Type Parameters
+///
+/// * `C` — The block cache implementation (typically `GlobalBlockCache`).
+pub struct NoteEngine<C: Cache> {
+    /// Reference to the underlying LSM engine.
+    engine: std::sync::Arc<crate::core::engine::Engine<C>>,
+    /// Column family used for note/index storage.
+    cf: String,
+}
+
+impl<C: Cache> NoteEngine<C> {
+    /// Create a new `NoteEngine` wrapping an existing LSM engine.
+    pub fn new(engine: std::sync::Arc<crate::core::engine::Engine<C>>) -> Self {
+        Self {
+            engine,
+            cf: "default".to_string(),
+        }
+    }
+
+    /// Create a `NoteEngine` with a custom column family.
+    pub fn with_cf(engine: std::sync::Arc<crate::core::engine::Engine<C>>, cf: &str) -> Self {
+        Self {
+            engine,
+            cf: cf.to_string(),
+        }
+    }
+
+    /// Return a reference to the underlying LSM engine.
+    pub fn engine(&self) -> &crate::core::engine::Engine<C> {
+        &self.engine
+    }
+
+    /// Return the column family used for note storage.
+    pub fn cf(&self) -> &str {
+        &self.cf
+    }
+
+    // ── Note CRUD ──────────────────────────────────────────────────────
+
+    /// Create or update a note. Automatically parses wikilinks and tags from
+    /// the content and updates the link/tag indexes.
+    pub fn put_note(&self, path: &str, content: &str) -> Result<()> {
+        let note_key = format!("note:{}", path);
+
+        // Parse the full note content
+        let parsed = parse_note(content);
+
+        // Store the note content
+        self.engine
+            .put_cf(&self.cf, note_key.into_bytes(), content.as_bytes().to_vec())?;
+
+        // Extract link targets (only WikiLink and BlockRef types)
+        let link_targets: Vec<String> = parsed
+            .links
+            .iter()
+            .filter(|l| matches!(l.link_type, parser::LinkType::WikiLink | parser::LinkType::BlockRef))
+            .map(|l| l.target.clone())
+            .collect();
+
+        // Update link indexes
+        NoteIndex::index_links(&self.engine, &self.cf, path, &link_targets)?;
+
+        // Update tag indexes
+        self.index_tags(path, &parsed.inline_tags)?;
+
+        Ok(())
+    }
+
+    /// Get a note's content by path.
+    pub fn get_note(&self, path: &str) -> Result<Option<String>> {
+        let note_key = format!("note:{}", path);
+        match self.engine.get_cf(&self.cf, note_key.into_bytes())? {
+            Some(bytes) => {
+                let content = String::from_utf8_lossy(&bytes).to_string();
+                Ok(Some(content))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Delete a note and clean up all its indexes.
+    pub fn delete_note(&self, path: &str) -> Result<()> {
+        let note_key = format!("note:{}", path);
+
+        // Remove link indexes
+        NoteIndex::remove_note_links(&self.engine, &self.cf, path)?;
+
+        // Remove tag indexes
+        self.remove_note_tags(path)?;
+
+        // Delete the note content
+        self.engine
+            .delete_cf(&self.cf, note_key.into_bytes())?;
+
+        Ok(())
+    }
+
+    /// Rename a note from `old_path` to `new_path`.
+    pub fn rename_note(&self, old_path: &str, new_path: &str) -> Result<()> {
+        // Get existing content
+        let content = self.get_note(old_path)?;
+        let content = match content {
+            Some(c) => c,
+            None => {
+                return Err(crate::infra::error::LsmError::InvalidArgument(format!(
+                    "Note not found: {}",
+                    old_path
+                )));
+            }
+        };
+
+        // Parse to get new links/tags
+        let parsed = parse_note(&content);
+        let link_targets: Vec<String> = parsed
+            .links
+            .iter()
+            .filter(|l| matches!(l.link_type, parser::LinkType::WikiLink | parser::LinkType::BlockRef))
+            .map(|l| l.target.clone())
+            .collect();
+
+        // Use NoteIndex to rename
+        NoteIndex::rename_note(&self.engine, &self.cf, old_path, new_path, &link_targets)?;
+
+        // Store content under new path
+        let new_note_key = format!("note:{}", new_path);
+        self.engine
+            .put_cf(&self.cf, new_note_key.into_bytes(), content.as_bytes().to_vec())?;
+
+        // Delete old note content
+        let old_note_key = format!("note:{}", old_path);
+        self.engine
+            .delete_cf(&self.cf, old_note_key.into_bytes())?;
+
+        Ok(())
+    }
+
+    /// List all notes, optionally filtered by a prefix.
+    pub fn list_notes(&self, prefix: Option<&str>) -> Result<Vec<String>> {
+        let search_prefix = match prefix {
+            Some(p) => format!("note:{}", p),
+            None => "note:".to_string(),
+        };
+
+        let (results, _cursor) = self
+            .engine
+            .search_prefix(&search_prefix, None, crate::core::engine::MAX_SCAN_LIMIT)?;
+
+        let paths: Vec<String> = results
+            .into_iter()
+            .map(|(k, _)| {
+                let key = String::from_utf8_lossy(&k).to_string();
+                key.strip_prefix("note:")
+                    .unwrap_or(&key)
+                    .to_string()
+            })
+            .collect();
+
+        Ok(paths)
+    }
+
+    // ── Tag management ─────────────────────────────────────────────────
+
+    /// Index tags for a note.
+    fn index_tags(&self, note_path: &str, tags: &[String]) -> Result<()> {
+        for tag in tags {
+            let tag_key = format!("tag:{}", tag);
+
+            // Get existing notes with this tag
+            let mut notes: Vec<String> = match self.engine.get_cf(&self.cf, tag_key.as_bytes())?
+            {
+                Some(bytes) => {
+                    let value = String::from_utf8_lossy(&bytes);
+                    serde_json::from_str(&value).unwrap_or_default()
+                }
+                None => Vec::new(),
+            };
+
+            // Add this note if not already present
+            if !notes.contains(&note_path.to_string()) {
+                notes.push(note_path.to_string());
+                let value = serde_json::to_string(&notes).map_err(|e| {
+                    crate::infra::error::LsmError::InvalidArgument(format!(
+                        "JSON error: {}",
+                        e
+                    ))
+                })?;
+                self.engine
+                    .put_cf(&self.cf, tag_key.into_bytes(), value.into_bytes())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Remove all tag indexes for a note.
+    fn remove_note_tags(&self, note_path: &str) -> Result<()> {
+        // Scan for tags containing this note
+        // Since we don't have a reverse tag index, we look up known tags
+        // via prefix scan
+        let (results, _cursor) = self
+            .engine
+            .search_prefix("tag:", None, crate::core::engine::MAX_SCAN_LIMIT)?;
+
+        for (key, value) in &results {
+            let mut notes: Vec<String> =
+                serde_json::from_str(&String::from_utf8_lossy(value)).unwrap_or_default();
+
+            if notes.contains(&note_path.to_string()) {
+                notes.retain(|n| n != note_path);
+
+                if notes.is_empty() {
+                    self.engine.delete_cf(&self.cf, key.clone())?;
+                } else {
+                    let new_value = serde_json::to_string(&notes).map_err(|e| {
+                        crate::infra::error::LsmError::InvalidArgument(format!(
+                            "JSON error: {}",
+                            e
+                        ))
+                    })?;
+                    self.engine
+                        .put_cf(&self.cf, key.clone(), new_value.into_bytes())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get all notes that have a specific tag.
+    pub fn get_notes_by_tag(&self, tag: &str) -> Result<Vec<String>> {
+        let tag_key = format!("tag:{}", tag);
+        match self.engine.get_cf(&self.cf, tag_key.into_bytes())? {
+            Some(bytes) => {
+                let value = String::from_utf8_lossy(&bytes);
+                let notes: Vec<String> = serde_json::from_str(&value).unwrap_or_default();
+                Ok(notes)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// List all tags with note counts.
+    pub fn list_tags(&self) -> Result<Vec<(String, usize)>> {
+        let (results, _cursor) = self
+            .engine
+            .search_prefix("tag:", None, crate::core::engine::MAX_SCAN_LIMIT)?;
+
+        let mut tags = Vec::new();
+        for (key, value) in &results {
+            let key_str = String::from_utf8_lossy(key).to_string();
+            if let Some(tag_name) = key_str.strip_prefix("tag:") {
+                let notes: Vec<String> =
+                    serde_json::from_str(&String::from_utf8_lossy(value)).unwrap_or_default();
+                tags.push((tag_name.to_string(), notes.len()));
+            }
+        }
+
+        Ok(tags)
+    }
+
+    // ── Graph ──────────────────────────────────────────────────────────
+
+    /// Build a graph centered on a specific note.
+    pub fn build_graph(&self, center_note: &str, config: &GraphConfig) -> Result<GraphData> {
+        NoteGraph::build_graph(&self.engine, &self.cf, center_note, config)
+    }
+
+    // ─── Snapshot / version history ───────────────────────────────────
+
+    /// Create a manual snapshot of the current note state.
+    pub fn create_snapshot(
+        &self,
+        label: &str,
+        time_travel: &mut crate::infra::time_travel::TimeTravelEngine,
+    ) -> u128 {
+        // Collect all notes
+        let notes = self.list_notes(None).unwrap_or_default();
+        let mut data = std::collections::HashMap::new();
+
+        for path in &notes {
+            if let Ok(Some(content)) = self.get_note(path) {
+                let key = format!("note:{}", path);
+                data.insert(key.into_bytes(), content.into_bytes());
+            }
+        }
+
+        time_travel.capture(data, label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::LsmConfig;
+    use crate::storage::cache::GlobalBlockCache;
+    use std::sync::Arc;
+
+    fn create_note_engine() -> NoteEngine<Arc<GlobalBlockCache>> {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = LsmConfig::default();
+        config.core.dir_path = dir.path().to_path_buf();
+        let engine = Arc::new(
+            crate::core::engine::Engine::new_from_config(
+                &config,
+                GlobalBlockCache::new(10, 4096),
+            )
+            .unwrap(),
+        );
+        NoteEngine::new(engine)
+    }
+
+    #[test]
+    fn test_put_and_get_note() {
+        let engine = create_note_engine();
+        engine.put_note("test-note", "# Hello World").unwrap();
+
+        let content = engine.get_note("test-note").unwrap();
+        assert_eq!(content, Some("# Hello World".to_string()));
+    }
+
+    #[test]
+    fn test_get_nonexistent_note() {
+        let engine = create_note_engine();
+        let content = engine.get_note("nonexistent").unwrap();
+        assert!(content.is_none());
+    }
+
+    #[test]
+    fn test_delete_note() {
+        let engine = create_note_engine();
+        engine.put_note("to-delete", "content").unwrap();
+        engine.delete_note("to-delete").unwrap();
+
+        let content = engine.get_note("to-delete").unwrap();
+        assert!(content.is_none());
+    }
+
+    #[test]
+    fn test_rename_note() {
+        let engine = create_note_engine();
+        engine.put_note("old-name", "# Hello").unwrap();
+        engine.rename_note("old-name", "new-name").unwrap();
+
+        let old = engine.get_note("old-name").unwrap();
+        assert!(old.is_none());
+
+        let new = engine.get_note("new-name").unwrap();
+        assert_eq!(new, Some("# Hello".to_string()));
+    }
+
+    #[test]
+    fn test_list_notes() {
+        let engine = create_note_engine();
+        engine.put_note("doc/a", "Note A").unwrap();
+        engine.put_note("doc/b", "Note B").unwrap();
+        engine.put_note("other/c", "Note C").unwrap();
+
+        let all = engine.list_notes(None).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let filtered = engine.list_notes(Some("doc/")).unwrap();
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn test_note_with_wikilinks_indexes_links() {
+        let engine = create_note_engine();
+        let content = "See [[target-note]] and [[another|Display]]";
+        engine.put_note("source-note", content).unwrap();
+
+        // Check forward links
+        let forward = NoteIndex::get_forward_links(engine.engine(), "default", "source-note").unwrap();
+        assert!(forward.contains(&"target-note".to_string()));
+        assert!(forward.contains(&"another".to_string()));
+
+        // Check backlinks from target perspective
+        let backlinks = NoteIndex::get_backlinks(engine.engine(), "default", "target-note").unwrap();
+        assert!(backlinks.contains(&"source-note".to_string()));
+    }
+
+    #[test]
+    fn test_note_with_tags() {
+        let engine = create_note_engine();
+        let content = "# Hello\n\nThis is #important and #rust";
+        engine.put_note("tagged-note", content).unwrap();
+
+        let notes = engine.get_notes_by_tag("important").unwrap();
+        assert!(notes.contains(&"tagged-note".to_string()));
+
+        let notes = engine.get_notes_by_tag("rust").unwrap();
+        assert!(notes.contains(&"tagged-note".to_string()));
+    }
+
+    #[test]
+    fn test_list_tags() {
+        let engine = create_note_engine();
+        engine.put_note("note-a", "#tag1 content").unwrap();
+        engine.put_note("note-b", "#tag1 and #tag2").unwrap();
+
+        let tags = engine.list_tags().unwrap();
+        assert!(tags.contains(&("tag1".to_string(), 2)));
+        assert!(tags.contains(&("tag2".to_string(), 1)));
+    }
+
+    #[test]
+    fn test_note_with_frontmatter() {
+        let engine = create_note_engine();
+        let content = "---\ntitle: My Note\ntags: [frontmatter-tag]\n---\n\nBody with #inline-tag";
+        engine.put_note("fm-note", content).unwrap();
+
+        // Tags from both frontmatter and inline should be indexed
+        let notes = engine.get_notes_by_tag("frontmatter-tag").unwrap();
+        assert!(notes.contains(&"fm-note".to_string()));
+
+        let notes = engine.get_notes_by_tag("inline-tag").unwrap();
+        assert!(notes.contains(&"fm-note".to_string()));
+    }
+
+    #[test]
+    fn test_graph_from_engine() {
+        let engine = create_note_engine();
+        engine.put_note("note-a", "Links to [[note-b]] and [[note-c]]").unwrap();
+        engine.put_note("note-b", "Links to [[note-c]]").unwrap();
+        engine.put_note("note-c", "Orphan").unwrap();
+
+        let graph = engine.build_graph("note-a", &GraphConfig::default()).unwrap();
+        assert!(graph.nodes.len() >= 2);
+        assert_eq!(graph.root, "note-a");
+    }
+
+    #[test]
+    fn test_create_snapshot() {
+        let engine = create_note_engine();
+        engine.put_note("snap-note", "Snapshot content").unwrap();
+
+        let mut time_travel = crate::infra::time_travel::TimeTravelEngine::new(10);
+        let ts = engine.create_snapshot("test-snapshot", &mut time_travel);
+
+        assert_eq!(time_travel.snapshot_count(), 1);
+        let snapshots = time_travel.list_snapshots();
+        assert_eq!(snapshots[0].1, "test-snapshot");
+
+        // Snapshot should contain the note
+        let data = time_travel.query_as_of(b"note:snap-note" as &[u8], ts + 1);
+        assert!(data.is_some());
+    }
+
+    #[test]
+    fn test_rename_updates_indexes() {
+        let engine = create_note_engine();
+
+        // Note-X links to Note-Y
+        engine.put_note("note-x", "See [[note-y]]").unwrap();
+
+        // Note-Z links to Note-X
+        engine.put_note("note-z", "See [[note-x]]").unwrap();
+
+        // Rename Note-X
+        engine.rename_note("note-x", "note-x-renamed").unwrap();
+
+        // Note-Z should now link to Note-X-renamed
+        let backlinks = NoteIndex::get_backlinks(engine.engine(), "default", "note-x-renamed").unwrap();
+        assert!(backlinks.contains(&"note-z".to_string()));
+
+        // Old Note-X should have no backlinks
+        let old_backlinks = NoteIndex::get_backlinks(engine.engine(), "default", "note-x").unwrap();
+        assert!(old_backlinks.is_empty());
+    }
+}

--- a/src/notes/mod.rs
+++ b/src/notes/mod.rs
@@ -52,6 +52,9 @@ pub use parser::{
     Wikilink,
 };
 
+/// Type alias for the note engine using the default LSM engine with `GlobalBlockCache`.
+pub type NotesEngine = NoteEngine<std::sync::Arc<crate::storage::cache::GlobalBlockCache>>;
+
 /// The high-level note engine that wraps the LSM storage engine and provides
 /// Obsidian-like note operations.
 ///
@@ -110,7 +113,12 @@ impl<C: Cache> NoteEngine<C> {
         let link_targets: Vec<String> = parsed
             .links
             .iter()
-            .filter(|l| matches!(l.link_type, parser::LinkType::WikiLink | parser::LinkType::BlockRef))
+            .filter(|l| {
+                matches!(
+                    l.link_type,
+                    parser::LinkType::WikiLink | parser::LinkType::BlockRef
+                )
+            })
             .map(|l| l.target.clone())
             .collect();
 
@@ -146,8 +154,7 @@ impl<C: Cache> NoteEngine<C> {
         self.remove_note_tags(path)?;
 
         // Delete the note content
-        self.engine
-            .delete_cf(&self.cf, note_key.into_bytes())?;
+        self.engine.delete_cf(&self.cf, note_key.into_bytes())?;
 
         Ok(())
     }
@@ -171,7 +178,12 @@ impl<C: Cache> NoteEngine<C> {
         let link_targets: Vec<String> = parsed
             .links
             .iter()
-            .filter(|l| matches!(l.link_type, parser::LinkType::WikiLink | parser::LinkType::BlockRef))
+            .filter(|l| {
+                matches!(
+                    l.link_type,
+                    parser::LinkType::WikiLink | parser::LinkType::BlockRef
+                )
+            })
             .map(|l| l.target.clone())
             .collect();
 
@@ -180,13 +192,15 @@ impl<C: Cache> NoteEngine<C> {
 
         // Store content under new path
         let new_note_key = format!("note:{}", new_path);
-        self.engine
-            .put_cf(&self.cf, new_note_key.into_bytes(), content.as_bytes().to_vec())?;
+        self.engine.put_cf(
+            &self.cf,
+            new_note_key.into_bytes(),
+            content.as_bytes().to_vec(),
+        )?;
 
         // Delete old note content
         let old_note_key = format!("note:{}", old_path);
-        self.engine
-            .delete_cf(&self.cf, old_note_key.into_bytes())?;
+        self.engine.delete_cf(&self.cf, old_note_key.into_bytes())?;
 
         Ok(())
     }
@@ -198,17 +212,15 @@ impl<C: Cache> NoteEngine<C> {
             None => "note:".to_string(),
         };
 
-        let (results, _cursor) = self
-            .engine
-            .search_prefix(&search_prefix, None, crate::core::engine::MAX_SCAN_LIMIT)?;
+        let (results, _cursor) =
+            self.engine
+                .search_prefix(&search_prefix, None, crate::core::engine::MAX_SCAN_LIMIT)?;
 
         let paths: Vec<String> = results
             .into_iter()
             .map(|(k, _)| {
                 let key = String::from_utf8_lossy(&k).to_string();
-                key.strip_prefix("note:")
-                    .unwrap_or(&key)
-                    .to_string()
+                key.strip_prefix("note:").unwrap_or(&key).to_string()
             })
             .collect();
 
@@ -223,8 +235,7 @@ impl<C: Cache> NoteEngine<C> {
             let tag_key = format!("tag:{}", tag);
 
             // Get existing notes with this tag
-            let mut notes: Vec<String> = match self.engine.get_cf(&self.cf, tag_key.as_bytes())?
-            {
+            let mut notes: Vec<String> = match self.engine.get_cf(&self.cf, tag_key.as_bytes())? {
                 Some(bytes) => {
                     let value = String::from_utf8_lossy(&bytes);
                     serde_json::from_str(&value).unwrap_or_default()
@@ -236,10 +247,7 @@ impl<C: Cache> NoteEngine<C> {
             if !notes.contains(&note_path.to_string()) {
                 notes.push(note_path.to_string());
                 let value = serde_json::to_string(&notes).map_err(|e| {
-                    crate::infra::error::LsmError::InvalidArgument(format!(
-                        "JSON error: {}",
-                        e
-                    ))
+                    crate::infra::error::LsmError::InvalidArgument(format!("JSON error: {}", e))
                 })?;
                 self.engine
                     .put_cf(&self.cf, tag_key.into_bytes(), value.into_bytes())?;
@@ -253,9 +261,9 @@ impl<C: Cache> NoteEngine<C> {
         // Scan for tags containing this note
         // Since we don't have a reverse tag index, we look up known tags
         // via prefix scan
-        let (results, _cursor) = self
-            .engine
-            .search_prefix("tag:", None, crate::core::engine::MAX_SCAN_LIMIT)?;
+        let (results, _cursor) =
+            self.engine
+                .search_prefix("tag:", None, crate::core::engine::MAX_SCAN_LIMIT)?;
 
         for (key, value) in &results {
             let mut notes: Vec<String> =
@@ -268,10 +276,7 @@ impl<C: Cache> NoteEngine<C> {
                     self.engine.delete_cf(&self.cf, key.clone())?;
                 } else {
                     let new_value = serde_json::to_string(&notes).map_err(|e| {
-                        crate::infra::error::LsmError::InvalidArgument(format!(
-                            "JSON error: {}",
-                            e
-                        ))
+                        crate::infra::error::LsmError::InvalidArgument(format!("JSON error: {}", e))
                     })?;
                     self.engine
                         .put_cf(&self.cf, key.clone(), new_value.into_bytes())?;
@@ -297,9 +302,9 @@ impl<C: Cache> NoteEngine<C> {
 
     /// List all tags with note counts.
     pub fn list_tags(&self) -> Result<Vec<(String, usize)>> {
-        let (results, _cursor) = self
-            .engine
-            .search_prefix("tag:", None, crate::core::engine::MAX_SCAN_LIMIT)?;
+        let (results, _cursor) =
+            self.engine
+                .search_prefix("tag:", None, crate::core::engine::MAX_SCAN_LIMIT)?;
 
         let mut tags = Vec::new();
         for (key, value) in &results {
@@ -312,6 +317,53 @@ impl<C: Cache> NoteEngine<C> {
         }
 
         Ok(tags)
+    }
+
+    /// Search notes by tag with cursor-based pagination.
+    ///
+    /// Returns a list of note paths and an optional cursor for the next page.
+    pub fn search_by_tag(
+        &self,
+        tag: &str,
+        cursor: Option<&str>,
+        limit: usize,
+    ) -> Result<(Vec<String>, Option<String>)> {
+        let (results, next_cursor) =
+            self.engine
+                .search_prefix(&format!("tag:{}", tag), cursor, limit)?;
+
+        let note_paths: Vec<String> = results
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let key_str = String::from_utf8_lossy(&k).to_string();
+                if key_str == format!("tag:{}", tag) {
+                    // The direct tag entry — parse its value array
+                    let notes: Vec<String> =
+                        serde_json::from_str(&String::from_utf8_lossy(&v)).unwrap_or_default();
+                    Some(notes)
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect();
+
+        Ok((
+            note_paths,
+            next_cursor.map(|c| String::from_utf8_lossy(c.as_ref()).to_string()),
+        ))
+    }
+
+    // ── Link index queries ──────────────────────────────────────────────
+
+    /// Get all notes that link TO the given note (incoming links).
+    pub fn get_backlinks(&self, note_path: &str) -> Result<Vec<String>> {
+        NoteIndex::get_backlinks(&self.engine, &self.cf, note_path)
+    }
+
+    /// Get all notes that the given note links TO (outgoing links).
+    pub fn get_forward_links(&self, note_path: &str) -> Result<Vec<String>> {
+        NoteIndex::get_forward_links(&self.engine, &self.cf, note_path)
     }
 
     // ── Graph ──────────────────────────────────────────────────────────
@@ -356,11 +408,8 @@ mod tests {
         let mut config = LsmConfig::default();
         config.core.dir_path = dir.path().to_path_buf();
         let engine = Arc::new(
-            crate::core::engine::Engine::new_from_config(
-                &config,
-                GlobalBlockCache::new(10, 4096),
-            )
-            .unwrap(),
+            crate::core::engine::Engine::new_from_config(&config, GlobalBlockCache::new(10, 4096))
+                .unwrap(),
         );
         NoteEngine::new(engine)
     }
@@ -425,12 +474,14 @@ mod tests {
         engine.put_note("source-note", content).unwrap();
 
         // Check forward links
-        let forward = NoteIndex::get_forward_links(engine.engine(), "default", "source-note").unwrap();
+        let forward =
+            NoteIndex::get_forward_links(engine.engine(), "default", "source-note").unwrap();
         assert!(forward.contains(&"target-note".to_string()));
         assert!(forward.contains(&"another".to_string()));
 
         // Check backlinks from target perspective
-        let backlinks = NoteIndex::get_backlinks(engine.engine(), "default", "target-note").unwrap();
+        let backlinks =
+            NoteIndex::get_backlinks(engine.engine(), "default", "target-note").unwrap();
         assert!(backlinks.contains(&"source-note".to_string()));
     }
 
@@ -475,11 +526,15 @@ mod tests {
     #[test]
     fn test_graph_from_engine() {
         let engine = create_note_engine();
-        engine.put_note("note-a", "Links to [[note-b]] and [[note-c]]").unwrap();
+        engine
+            .put_note("note-a", "Links to [[note-b]] and [[note-c]]")
+            .unwrap();
         engine.put_note("note-b", "Links to [[note-c]]").unwrap();
         engine.put_note("note-c", "Orphan").unwrap();
 
-        let graph = engine.build_graph("note-a", &GraphConfig::default()).unwrap();
+        let graph = engine
+            .build_graph("note-a", &GraphConfig::default())
+            .unwrap();
         assert!(graph.nodes.len() >= 2);
         assert_eq!(graph.root, "note-a");
     }
@@ -515,7 +570,8 @@ mod tests {
         engine.rename_note("note-x", "note-x-renamed").unwrap();
 
         // Note-Z should now link to Note-X-renamed
-        let backlinks = NoteIndex::get_backlinks(engine.engine(), "default", "note-x-renamed").unwrap();
+        let backlinks =
+            NoteIndex::get_backlinks(engine.engine(), "default", "note-x-renamed").unwrap();
         assert!(backlinks.contains(&"note-z".to_string()));
 
         // Old Note-X should have no backlinks

--- a/src/notes/parser.rs
+++ b/src/notes/parser.rs
@@ -1,0 +1,633 @@
+//! Wikilink, tag, and YAML frontmatter parser for Obsidian-compatible notes.
+//!
+//! # Syntax support
+//!
+//! - `[[Note Name]]` — basic wikilink
+//! - `[[Note Name|Display Text]]` — wikilink with alias
+//! - `[[#heading]]` — link to heading in same note
+//! - `[[Note Name#heading]]` — link to heading in another note
+//! - `[[Note Name|Display#heading]]` — combined
+//! - `[[Note Name#^block-id]]` — block reference
+//! - `![[image.png]]` — embedded file / embed
+//! - `#tag` — inline tag
+//! - `#tag/subtag` — nested tag
+
+use std::collections::HashMap;
+
+/// The type of a parsed link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinkType {
+    /// `[[Note Name]]` or `[[Note Name|Display]]`
+    WikiLink,
+    /// `![[file.png]]` — embedded file
+    Embed,
+    /// `[[#heading]]` — heading reference within same note
+    HeadingRef,
+    /// `[[Note Name#^block-id]]` — block reference
+    BlockRef,
+}
+
+/// A single parsed wikilink with its position in the source content.
+#[derive(Debug, Clone)]
+pub struct Wikilink {
+    /// The target note path, heading, or block ID.
+    pub target: String,
+    /// Optional display text (e.g., `[[target|display]]`).
+    pub display_text: Option<String>,
+    /// The type of link.
+    pub link_type: LinkType,
+    /// Byte offset where the link starts in the original content.
+    pub start_offset: usize,
+    /// Byte offset where the link ends in the original content.
+    pub end_offset: usize,
+}
+
+/// Parsed YAML frontmatter from a note.
+#[derive(Debug, Clone, Default)]
+pub struct Frontmatter {
+    /// Note title from `title:` field.
+    pub title: Option<String>,
+    /// Alternative names from `aliases:` field.
+    pub aliases: Vec<String>,
+    /// Tags from `tags:` field.
+    pub tags: Vec<String>,
+    /// Creation date from `created:` field.
+    pub created: Option<String>,
+    /// Last update date from `updated:` field.
+    pub updated: Option<String>,
+    /// Any other custom frontmatter fields.
+    pub custom: HashMap<String, String>,
+}
+
+/// The result of parsing a note's content.
+#[derive(Debug, Clone)]
+pub struct ParsedNote {
+    /// The raw markdown content (after stripping frontmatter).
+    pub content: String,
+    /// Extracted wikilinks.
+    pub links: Vec<Wikilink>,
+    /// Extracted inline tags (from `#tag` syntax in content).
+    pub inline_tags: Vec<String>,
+    /// Parsed frontmatter (YAML between `---` markers).
+    pub frontmatter: Frontmatter,
+}
+
+/// Extract all `[[wikilinks]]` from markdown content.
+///
+/// Supports:
+/// - `[[target]]`
+/// - `[[target|display]]`
+/// - `[[#heading]]`
+/// - `[[target#heading]]`
+/// - `[[target#^block-id]]`
+/// - `![[embed]]`
+pub fn parse_wikilinks(content: &str) -> Vec<Wikilink> {
+    let mut links = Vec::new();
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        // Check for `![[` (embed) or `[[` (link)
+        if i + 1 < len {
+            let is_embed = bytes[i] == b'!' && i + 2 < len && bytes[i + 1] == b'[' && bytes[i + 2] == b'[';
+            let is_link = bytes[i] == b'[' && i + 1 < len && bytes[i + 1] == b'[';
+
+            if is_embed || is_link {
+                let start = i;
+                let content_start = if is_embed { i + 3 } else { i + 2 };
+
+                // Find the closing `]]`
+                if let Some(end) = find_closing_brackets(bytes, content_start) {
+                    let inner = &content[content_start..end];
+                    let link_type = if is_embed {
+                        LinkType::Embed
+                    } else if inner.starts_with('#') {
+                        if inner.contains('^') {
+                            LinkType::BlockRef
+                        } else {
+                            LinkType::HeadingRef
+                        }
+                    } else if inner.contains('#') {
+                        if inner.contains("^block") || inner.contains('^') {
+                            LinkType::BlockRef
+                        } else {
+                            LinkType::WikiLink
+                        }
+                    } else {
+                        LinkType::WikiLink
+                    };
+
+                    let (target, display_text) = if let Some(pipe_pos) = inner.find('|') {
+                        let target = inner[..pipe_pos].trim().to_string();
+                        let display = inner[pipe_pos + 1..].trim().to_string();
+                        (target, if display.is_empty() { None } else { Some(display) })
+                    } else {
+                        (inner.trim().to_string(), None)
+                    };
+
+                    links.push(Wikilink {
+                        target,
+                        display_text,
+                        link_type,
+                        start_offset: start,
+                        end_offset: end + 2,
+                    });
+
+                    i = end + 2;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    links
+}
+
+/// Find the closing `]]` for a wikilink starting at `start`.
+/// Returns the index of the first `]` in the closing `]]`.
+fn find_closing_brackets(bytes: &[u8], mut start: usize) -> Option<usize> {
+    while start + 1 < bytes.len() {
+        if bytes[start] == b']' && bytes[start + 1] == b']' {
+            return Some(start);
+        }
+        start += 1;
+    }
+    None
+}
+
+/// Extract all `#tags` from markdown content.
+///
+/// Rules:
+/// - Tag must start with `#` at a word boundary
+/// - Allowed chars: `[a-zA-Z0-9_/-]`
+/// - Tags inside code blocks, inline code, and HTML comments are ignored
+/// - Nested tags (`#tag/subtag`) are stored as full path
+/// - Max tag length: 100 chars
+pub fn parse_tags(content: &str) -> Vec<String> {
+    let mut tags = Vec::new();
+    let mut in_code_block = false;
+    let mut in_inline_code = false;
+    let mut in_html_comment = false;
+    let mut i = 0;
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+
+    while i < len {
+        // Track code blocks (```)
+        if i + 2 < len && &bytes[i..i+3] == b"```" {
+            in_code_block = !in_code_block;
+            i += 3;
+            continue;
+        }
+
+        // Track inline code (`)
+        if bytes[i] == b'`' && !in_code_block {
+            in_inline_code = !in_inline_code;
+            i += 1;
+            continue;
+        }
+
+        // Track HTML comments (<!-- -->)
+        if i + 3 < len && &bytes[i..i+4] == b"<!--" {
+            in_html_comment = true;
+            i += 4;
+            continue;
+        }
+        if in_html_comment && i + 2 < len && &bytes[i..i+3] == b"-->" {
+            in_html_comment = false;
+            i += 3;
+            continue;
+        }
+
+        if !in_code_block && !in_inline_code && !in_html_comment && bytes[i] == b'#' {
+            // Check it's at a word boundary (not preceded by alphanumeric)
+            if i == 0 || is_tag_boundary(bytes[i - 1]) {
+                let tag_start = i + 1;
+                let mut tag_end = tag_start;
+                while tag_end < len && is_tag_char(bytes[tag_end]) {
+                    tag_end += 1;
+                }
+                if tag_end > tag_start && (tag_end - tag_start) <= 100 {
+                    let tag = content[tag_start..tag_end].to_string();
+                    if !tags.contains(&tag) {
+                        tags.push(tag);
+                    }
+                }
+                i = tag_end;
+                continue;
+            }
+        }
+
+        i += 1;
+    }
+
+    tags
+}
+
+/// Returns true if the byte is a valid tag boundary (not alphanumeric).
+fn is_tag_boundary(b: u8) -> bool {
+    !b.is_ascii_alphanumeric() && b != b'_'
+}
+
+/// Returns true if the byte is a valid tag character.
+fn is_tag_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'/' || b == b'-'
+}
+
+/// Parse YAML frontmatter between `---` markers.
+///
+/// Returns the parsed frontmatter and the content after the frontmatter block.
+pub fn parse_frontmatter(content: &str) -> (Frontmatter, &str) {
+    let content = content.trim_start();
+    if !content.starts_with("---") {
+        return (Frontmatter::default(), content);
+    }
+
+    // Find the closing `---`
+    let after_first = &content[3..];
+    if let Some(end) = after_first.find("\n---") {
+        let yaml_block = &after_first[..end];
+        let fm = parse_yaml_block(yaml_block);
+        let rest = after_first[end + 4..].trim_start();
+        (fm, rest)
+    } else {
+        (Frontmatter::default(), content)
+    }
+}
+
+/// Parse a block of YAML key-value pairs.
+fn parse_yaml_block(block: &str) -> Frontmatter {
+    let mut fm = Frontmatter::default();
+    let mut lines: Vec<&str> = Vec::new();
+
+    // Collect all non-empty lines
+    for line in block.lines() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            lines.push(trimmed);
+        }
+    }
+
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        if let Some((key, value)) = line.split_once(':') {
+            let key = key.trim().to_lowercase();
+            let value = value.trim();
+
+            if value.is_empty() || value.starts_with('[') || value.starts_with('-') {
+                // Multi-line value (list)
+                let mut list_values = Vec::new();
+
+                if value.starts_with('[') && value.ends_with(']') {
+                    // Parse `[item1, item2, ...]` inline list
+                    let inner = value.trim_start_matches('[').trim_end_matches(']');
+                    list_values = inner.split(',')
+                        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                } else {
+                    // Parse list items starting with `- ` on following lines
+                    i += 1;
+                    while i < lines.len() {
+                        let next = lines[i];
+                        if let Some(item) = next.strip_prefix("- ") {
+                            list_values.push(item.trim().to_string());
+                            i += 1;
+                        } else if let Some(item) = next.strip_prefix('-') {
+                            list_values.push(item.trim().to_string());
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                match key.as_str() {
+                    "aliases" => fm.aliases = list_values,
+                    "tags" => fm.tags = list_values,
+                    _ => {
+                        for v in list_values {
+                            fm.custom.insert(format!("{}_item", key), v);
+                        }
+                    }
+                }
+            } else {
+                match key.as_str() {
+                    "title" => fm.title = Some(value.trim_matches('"').trim_matches('\'').to_string()),
+                    "created" => fm.created = Some(value.to_string()),
+                    "updated" => fm.updated = Some(value.to_string()),
+                    "tags" => {
+                        // Single tag value
+                        let tag = value.trim_matches('"').trim_matches('\'').to_string();
+                        if !tag.is_empty() {
+                            fm.tags.push(tag);
+                        }
+                    }
+                    _ => {
+                        fm.custom.insert(key, value.trim_matches('"').trim_matches('\'').to_string());
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+
+    fm
+}
+
+/// Parse a complete note: extract frontmatter, wikilinks, and tags.
+pub fn parse_note(content: &str) -> ParsedNote {
+    let (frontmatter, body) = parse_frontmatter(content);
+    let links = parse_wikilinks(body);
+    let inline_tags = parse_tags(body);
+
+    // Merge frontmatter tags with inline tags (dedup)
+    let mut all_tags = frontmatter.tags.clone();
+    for tag in &inline_tags {
+        if !all_tags.contains(tag) {
+            all_tags.push(tag.clone());
+        }
+    }
+
+    ParsedNote {
+        content: body.to_string(),
+        links,
+        inline_tags: all_tags,
+        frontmatter,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Wikilink tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_basic_wikilink() {
+        let links = parse_wikilinks("Hello [[Note Name]] world");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "Note Name");
+        assert_eq!(links[0].link_type, LinkType::WikiLink);
+        assert_eq!(links[0].display_text, None);
+    }
+
+    #[test]
+    fn test_wikilink_with_alias() {
+        let links = parse_wikilinks("See [[target|display text]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "target");
+        assert_eq!(links[0].display_text, Some("display text".to_string()));
+    }
+
+    #[test]
+    fn test_wikilink_empty_alias() {
+        let links = parse_wikilinks("See [[target|]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "target");
+        assert_eq!(links[0].display_text, None);
+    }
+
+    #[test]
+    fn test_embed_wikilink() {
+        let links = parse_wikilinks("![[image.png]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "image.png");
+        assert_eq!(links[0].link_type, LinkType::Embed);
+    }
+
+    #[test]
+    fn test_heading_ref() {
+        let links = parse_wikilinks("See [[#installation]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "#installation");
+        assert_eq!(links[0].link_type, LinkType::HeadingRef);
+    }
+
+    #[test]
+    fn test_note_with_heading_ref() {
+        let links = parse_wikilinks("See [[Note Name#installation]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "Note Name#installation");
+        assert_eq!(links[0].link_type, LinkType::WikiLink);
+    }
+
+    #[test]
+    fn test_block_ref() {
+        let links = parse_wikilinks("See [[Note Name#^block-id]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "Note Name#^block-id");
+        assert_eq!(links[0].link_type, LinkType::BlockRef);
+    }
+
+    #[test]
+    fn test_multiple_wikilinks() {
+        let links = parse_wikilinks("[[A]] and [[B|b]] and [[C]]");
+        assert_eq!(links.len(), 3);
+        assert_eq!(links[0].target, "A");
+        assert_eq!(links[1].target, "B");
+        assert_eq!(links[2].target, "C");
+    }
+
+    #[test]
+    fn test_no_wikilinks() {
+        let links = parse_wikilinks("Just plain text");
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn test_unclosed_bracket() {
+        let links = parse_wikilinks("[[unclosed");
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn test_wikilink_with_special_chars() {
+        let links = parse_wikilinks("[[my-note_v2/readme]]");
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target, "my-note_v2/readme");
+    }
+
+    #[test]
+    fn test_wikilink_positions() {
+        let links = parse_wikilinks("prefix [[link]] suffix");
+        assert_eq!(links.len(), 1);
+        assert_eq!(&links[0].target, "link");
+        // The link starts at position 7 (0-indexed, after "prefix ")
+        assert_eq!(links[0].start_offset, 7);
+        assert_eq!(links[0].end_offset, 15);
+    }
+
+    #[test]
+    fn test_wikilink_alias_with_pipe() {
+        let links = parse_wikilinks("[[note|display with spaces]]");
+        assert_eq!(links[0].target, "note");
+        assert_eq!(links[0].display_text, Some("display with spaces".to_string()));
+    }
+
+    // ── Tag tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_basic_tag() {
+        let tags = parse_tags("This is a #tag in text");
+        assert_eq!(tags, vec!["tag"]);
+    }
+
+    #[test]
+    fn test_multiple_tags() {
+        let tags = parse_tags("#rust and #web and #database");
+        assert_eq!(tags, vec!["rust", "web", "database"]);
+    }
+
+    #[test]
+    fn test_nested_tag() {
+        let tags = parse_tags("Topic #tech/rust/async");
+        assert_eq!(tags, vec!["tech/rust/async"]);
+    }
+
+    #[test]
+    fn test_tag_with_hyphen() {
+        let tags = parse_tags("Tagged #my-tag_name");
+        assert_eq!(tags, vec!["my-tag_name"]);
+    }
+
+    #[test]
+    fn test_tag_inside_code_block() {
+        let tags = parse_tags("Text\n```\n#tag_inside_code\n```\nMore text");
+        let empty: Vec<String> = Vec::new();
+        assert_eq!(tags, empty);
+    }
+
+    #[test]
+    fn test_tag_after_hash_in_url() {
+        // `#` in URL fragment should not be parsed as tag
+        // The `#section` in `page#section` is preceded by alphanumeric `e`,
+        // so the tag boundary check correctly rejects it.
+        let tags = parse_tags("Check https://example.com/page#section");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_no_tags() {
+        let tags = parse_tags("Plain text with no hash symbols");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_tag_dedup() {
+        let tags = parse_tags("#rust #rust #web");
+        assert_eq!(tags, vec!["rust", "web"]);
+    }
+
+    #[test]
+    fn test_tag_length_limit() {
+        let long_tag = format!("#{}", "a".repeat(150));
+        let tags = parse_tags(&long_tag);
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_tag_in_inline_code() {
+        let tags = parse_tags("Text `#tag_inside_code` more text");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_tag_in_html_comment() {
+        let tags = parse_tags("Text <!-- #tag_in_comment --> more text");
+        assert!(tags.is_empty());
+    }
+
+    // ── Frontmatter tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_basic_frontmatter() {
+        let content = "---\ntitle: My Note\ncreated: 2026-05-25\n---\n\nNote content here";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.title, Some("My Note".to_string()));
+        assert_eq!(fm.created, Some("2026-05-25".to_string()));
+        assert_eq!(body, "Note content here");
+    }
+
+    #[test]
+    fn test_no_frontmatter() {
+        let (fm, body) = parse_frontmatter("Just content");
+        assert_eq!(fm.title, None);
+        assert_eq!(body, "Just content");
+    }
+
+    #[test]
+    fn test_frontmatter_with_tags_list() {
+        let content = "---\ntitle: Project\ntags: [rust, web, database]\n---\n\nBody";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.title, Some("Project".to_string()));
+        assert_eq!(fm.tags, vec!["rust", "web", "database"]);
+        assert_eq!(body, "Body");
+    }
+
+    #[test]
+    fn test_frontmatter_with_aliases() {
+        let content = "---\ntitle: My Note\naliases: [MN, My-Note]\n---\n\nBody";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.aliases, vec!["MN", "My-Note"]);
+        assert_eq!(body, "Body");
+    }
+
+    #[test]
+    fn test_frontmatter_with_custom_fields() {
+        let content = "---\ntitle: Note\nstatus: draft\nauthor: Alice\n---\n\nBody";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.custom.get("status"), Some(&"draft".to_string()));
+        assert_eq!(fm.custom.get("author"), Some(&"Alice".to_string()));
+        assert_eq!(body, "Body");
+    }
+
+    #[test]
+    fn test_frontmatter_with_yaml_list() {
+        let content = "---\ntags:\n  - rust\n  - web\n  - database\n---\n\nBody";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.tags, vec!["rust", "web", "database"]);
+        assert_eq!(body, "Body");
+    }
+
+    #[test]
+    fn test_frontmatter_empty() {
+        let content = "---\n---\n\nBody";
+        let (fm, body) = parse_frontmatter(content);
+        assert_eq!(fm.title, None);
+        assert_eq!(body, "Body");
+    }
+
+    // ── Full note parse tests ───────────────────────────────────────────
+
+    #[test]
+    fn test_parse_full_note() {
+        let content = "---\ntitle: My Project\ncreated: 2026-05-25\ntags: [rust, web]\n---\n\n# My Project\n\nThis is about [[feature-x]] and [[feature-y|Y Feature]].\n\nSome #important notes here.";
+        let parsed = parse_note(content);
+
+        assert_eq!(parsed.frontmatter.title, Some("My Project".to_string()));
+        assert_eq!(parsed.content, "# My Project\n\nThis is about [[feature-x]] and [[feature-y|Y Feature]].\n\nSome #important notes here.");
+
+        // 2 wikilinks
+        assert_eq!(parsed.links.len(), 2);
+        assert_eq!(parsed.links[0].target, "feature-x");
+        assert_eq!(parsed.links[1].target, "feature-y");
+
+        // Tags from frontmatter + inline, deduped
+        assert!(parsed.inline_tags.contains(&"rust".to_string()));
+        assert!(parsed.inline_tags.contains(&"web".to_string()));
+        assert!(parsed.inline_tags.contains(&"important".to_string()));
+    }
+
+    #[test]
+    fn test_parse_note_no_frontmatter() {
+        let content = "Just a simple note with [[a link]] and #tag";
+        let parsed = parse_note(content);
+        assert_eq!(parsed.frontmatter.title, None);
+        assert_eq!(parsed.links.len(), 1);
+        assert_eq!(parsed.inline_tags, vec!["tag"]);
+    }
+}

--- a/src/notes/parser.rs
+++ b/src/notes/parser.rs
@@ -12,6 +12,7 @@
 //! - `#tag` — inline tag
 //! - `#tag/subtag` — nested tag
 
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// The type of a parsed link.
@@ -43,7 +44,7 @@ pub struct Wikilink {
 }
 
 /// Parsed YAML frontmatter from a note.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Frontmatter {
     /// Note title from `title:` field.
     pub title: Option<String>,
@@ -90,7 +91,8 @@ pub fn parse_wikilinks(content: &str) -> Vec<Wikilink> {
     while i < len {
         // Check for `![[` (embed) or `[[` (link)
         if i + 1 < len {
-            let is_embed = bytes[i] == b'!' && i + 2 < len && bytes[i + 1] == b'[' && bytes[i + 2] == b'[';
+            let is_embed =
+                bytes[i] == b'!' && i + 2 < len && bytes[i + 1] == b'[' && bytes[i + 2] == b'[';
             let is_link = bytes[i] == b'[' && i + 1 < len && bytes[i + 1] == b'[';
 
             if is_embed || is_link {
@@ -121,7 +123,14 @@ pub fn parse_wikilinks(content: &str) -> Vec<Wikilink> {
                     let (target, display_text) = if let Some(pipe_pos) = inner.find('|') {
                         let target = inner[..pipe_pos].trim().to_string();
                         let display = inner[pipe_pos + 1..].trim().to_string();
-                        (target, if display.is_empty() { None } else { Some(display) })
+                        (
+                            target,
+                            if display.is_empty() {
+                                None
+                            } else {
+                                Some(display)
+                            },
+                        )
                     } else {
                         (inner.trim().to_string(), None)
                     };
@@ -176,7 +185,7 @@ pub fn parse_tags(content: &str) -> Vec<String> {
 
     while i < len {
         // Track code blocks (```)
-        if i + 2 < len && &bytes[i..i+3] == b"```" {
+        if i + 2 < len && &bytes[i..i + 3] == b"```" {
             in_code_block = !in_code_block;
             i += 3;
             continue;
@@ -190,12 +199,12 @@ pub fn parse_tags(content: &str) -> Vec<String> {
         }
 
         // Track HTML comments (<!-- -->)
-        if i + 3 < len && &bytes[i..i+4] == b"<!--" {
+        if i + 3 < len && &bytes[i..i + 4] == b"<!--" {
             in_html_comment = true;
             i += 4;
             continue;
         }
-        if in_html_comment && i + 2 < len && &bytes[i..i+3] == b"-->" {
+        if in_html_comment && i + 2 < len && &bytes[i..i + 3] == b"-->" {
             in_html_comment = false;
             i += 3;
             continue;
@@ -284,7 +293,8 @@ fn parse_yaml_block(block: &str) -> Frontmatter {
                 if value.starts_with('[') && value.ends_with(']') {
                     // Parse `[item1, item2, ...]` inline list
                     let inner = value.trim_start_matches('[').trim_end_matches(']');
-                    list_values = inner.split(',')
+                    list_values = inner
+                        .split(',')
                         .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
                         .filter(|s| !s.is_empty())
                         .collect();
@@ -316,7 +326,9 @@ fn parse_yaml_block(block: &str) -> Frontmatter {
                 }
             } else {
                 match key.as_str() {
-                    "title" => fm.title = Some(value.trim_matches('"').trim_matches('\'').to_string()),
+                    "title" => {
+                        fm.title = Some(value.trim_matches('"').trim_matches('\'').to_string())
+                    }
                     "created" => fm.created = Some(value.to_string()),
                     "updated" => fm.updated = Some(value.to_string()),
                     "tags" => {
@@ -327,7 +339,8 @@ fn parse_yaml_block(block: &str) -> Frontmatter {
                         }
                     }
                     _ => {
-                        fm.custom.insert(key, value.trim_matches('"').trim_matches('\'').to_string());
+                        fm.custom
+                            .insert(key, value.trim_matches('"').trim_matches('\'').to_string());
                     }
                 }
             }
@@ -465,7 +478,10 @@ mod tests {
     fn test_wikilink_alias_with_pipe() {
         let links = parse_wikilinks("[[note|display with spaces]]");
         assert_eq!(links[0].target, "note");
-        assert_eq!(links[0].display_text, Some("display with spaces".to_string()));
+        assert_eq!(
+            links[0].display_text,
+            Some("display with spaces".to_string())
+        );
     }
 
     // ── Tag tests ───────────────────────────────────────────────────────

--- a/src/notes/search.rs
+++ b/src/notes/search.rs
@@ -1,0 +1,460 @@
+//! Full-text search for note content using an inverted index.
+//!
+//! Storage schema:
+//!
+//! ```text
+//! cf "default":
+//!   fts:{term}                → JSON array of { path, count, last_indexed }
+//!   fts:meta:{note_path}      → JSON { checksum, word_count }
+//! ```
+//!
+//! Tokenization rules:
+//! - Split on whitespace and punctuation
+//! - Lowercase all terms
+//! - Min word length: 2 chars
+//! - Max word length: 50 chars
+//! - Stop words removed (configurable)
+
+use crate::infra::error::{LsmError, Result};
+use crate::storage::cache::Cache;
+use serde::{Deserialize, Serialize};
+
+/// A single term entry in the inverted index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TermEntry {
+    /// Note path containing this term.
+    path: String,
+    /// How many times the term appears in the note.
+    count: usize,
+}
+
+/// Metadata about a note's indexed content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FtsMeta {
+    /// Checksum to detect content changes.
+    checksum: u64,
+    /// Total word count in the note.
+    word_count: usize,
+}
+
+/// A search result hit.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchHit {
+    /// Note path.
+    pub path: String,
+    /// Relevance score (approximate TF-IDF).
+    pub score: f64,
+    /// Content snippet with highlighted terms.
+    pub snippet: String,
+}
+
+/// The full-text search engine.
+pub struct FullTextSearch;
+
+/// Default stop words to filter out.
+const STOP_WORDS: &[&str] = &[
+    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for", "of", "with", "by",
+    "from", "as", "is", "was", "are", "were", "be", "been", "being", "have", "has", "had", "do",
+    "does", "did", "will", "would", "could", "should", "may", "might", "shall", "can", "not", "no",
+    "nor", "so", "if", "then", "than", "that", "this", "these", "those", "it", "its", "he", "she",
+    "they", "them", "we", "you", "all", "each", "every", "some", "any", "both", "few", "more",
+    "most", "other", "such", "only", "own", "same", "too", "very", "just", "also", "about",
+    "above", "after", "again", "against", "below", "between", "into", "through", "during",
+    "before", "after", "up", "down", "out", "off", "over", "under", "here", "there", "where",
+    "why", "how",
+];
+
+impl FullTextSearch {
+    /// Tokenize content into terms.
+    fn tokenize(content: &str) -> Vec<String> {
+        let mut terms = Vec::new();
+        let mut current = String::new();
+
+        for ch in content.chars() {
+            if ch.is_alphanumeric() {
+                current.push(ch);
+            } else {
+                if !current.is_empty() {
+                    let term = current.to_lowercase();
+                    if term.len() >= 2 && term.len() <= 50 && !STOP_WORDS.contains(&term.as_str()) {
+                        terms.push(term);
+                    }
+                    current.clear();
+                }
+            }
+        }
+
+        // Handle last term
+        if !current.is_empty() {
+            let term = current.to_lowercase();
+            if term.len() >= 2 && term.len() <= 50 && !STOP_WORDS.contains(&term.as_str()) {
+                terms.push(term);
+            }
+        }
+
+        terms
+    }
+
+    /// Compute a simple hash for change detection.
+    fn checksum(content: &str) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        content.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Index a single note — updates the inverted index with the note's terms.
+    /// Only re-indexes if content has changed (detected via checksum).
+    pub fn index_note<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        path: &str,
+        content: &str,
+    ) -> Result<()> {
+        let meta_key = format!("fts:meta:{}", path);
+        let new_checksum = Self::checksum(content);
+
+        // Check if content changed since last index
+        if let Some(bytes) = engine.get_cf(cf, meta_key.as_bytes())? {
+            let meta: FtsMeta = serde_json::from_slice(&bytes)
+                .map_err(|e| LsmError::InvalidArgument(format!("FTS meta: {}", e)))?;
+            if meta.checksum == new_checksum {
+                return Ok(()); // Unchanged
+            }
+        }
+
+        let terms = Self::tokenize(content);
+        let word_count = terms.len();
+
+        // Build term frequency map
+        let mut tf_map: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        for term in &terms {
+            *tf_map.entry(term.clone()).or_insert(0) += 1;
+        }
+
+        // Update inverted index for each term
+        for (term, count) in &tf_map {
+            let fts_key = format!("fts:{}", term);
+            let mut entries: Vec<TermEntry> = match engine.get_cf(cf, fts_key.as_bytes())? {
+                Some(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+                None => Vec::new(),
+            };
+
+            // Update or insert entry for this note
+            if let Some(existing) = entries.iter_mut().find(|e| e.path == path) {
+                existing.count = *count;
+            } else {
+                entries.push(TermEntry {
+                    path: path.to_string(),
+                    count: *count,
+                });
+            }
+
+            let value = serde_json::to_vec(&entries)
+                .map_err(|e| LsmError::InvalidArgument(format!("FTS serialization: {}", e)))?;
+            engine.put_cf(cf, fts_key.into_bytes(), value)?;
+        }
+
+        // Store metadata
+        let meta = FtsMeta {
+            checksum: new_checksum,
+            word_count,
+        };
+        let meta_value = serde_json::to_vec(&meta)
+            .map_err(|e| LsmError::InvalidArgument(format!("FTS meta: {}", e)))?;
+        engine.put_cf(cf, meta_key.into_bytes(), meta_value)?;
+
+        Ok(())
+    }
+
+    /// Remove all index entries for a note.
+    pub fn remove_note<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        path: &str,
+    ) -> Result<()> {
+        // Find all terms pointing to this note by scanning fts: prefix
+        let (results, _) = engine.search_prefix("fts:", None, 10_000)?;
+        let mut terms_to_update: Vec<(String, Vec<TermEntry>)> = Vec::new();
+
+        for (key_bytes, value_bytes) in &results {
+            let key = String::from_utf8_lossy(key_bytes);
+            if let Some(term) = key.strip_prefix("fts:") {
+                if !term.starts_with("meta:") {
+                    let mut entries: Vec<TermEntry> =
+                        serde_json::from_slice(value_bytes).unwrap_or_default();
+                    if entries.iter().any(|e| e.path == path) {
+                        entries.retain(|e| e.path != path);
+                        terms_to_update.push((term.to_string(), entries));
+                    }
+                }
+            }
+        }
+
+        for (term, entries) in &terms_to_update {
+            let fts_key = format!("fts:{}", term);
+            if entries.is_empty() {
+                engine.delete_cf(cf, fts_key.into_bytes())?;
+            } else {
+                let value = serde_json::to_vec(entries)
+                    .map_err(|e| LsmError::InvalidArgument(format!("FTS: {}", e)))?;
+                engine.put_cf(cf, fts_key.into_bytes(), value)?;
+            }
+        }
+
+        // Remove metadata
+        let meta_key = format!("fts:meta:{}", path);
+        engine.delete_cf(cf, meta_key.into_bytes())?;
+
+        Ok(())
+    }
+
+    /// Search for notes matching the given query.
+    ///
+    /// Supports:
+    /// - `keyword` — basic term search
+    /// - `"exact phrase"` — phrase search
+    ///
+    /// Returns results sorted by relevance (descending), with snippets.
+    pub fn search<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        query: &str,
+        max_results: usize,
+    ) -> Result<Vec<SearchHit>> {
+        let query = query.trim();
+
+        // Check for phrase search
+        if query.starts_with('"') && query.ends_with('"') && query.len() > 1 {
+            let phrase = &query[1..query.len() - 1];
+            let phrase_terms = Self::tokenize(phrase);
+            return Self::search_phrase(engine, cf, &phrase_terms, max_results);
+        }
+
+        // Simple keyword search
+        let terms = Self::tokenize(query);
+        if terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Score each note across all query terms
+        let mut scores: std::collections::HashMap<String, (f64, usize)> =
+            std::collections::HashMap::new();
+        let total_notes = 100.0; // Estimate for IDF normalization
+
+        for term in &terms {
+            let fts_key = format!("fts:{}", term);
+            if let Some(bytes) = engine.get_cf(cf, fts_key.as_bytes())? {
+                let entries: Vec<TermEntry> = serde_json::from_slice(&bytes).unwrap_or_default();
+
+                let df = entries.len() as f64;
+                let idf = (total_notes / (df + 1.0)).ln() + 1.0;
+
+                for entry in entries {
+                    let tf = (entry.count as f64).ln() + 1.0;
+                    let score = tf * idf;
+                    let current = scores.entry(entry.path).or_insert((0.0, 0));
+                    current.0 += score;
+                    current.1 += entry.count;
+                }
+            }
+        }
+
+        // Sort by score descending
+        let mut results: Vec<(String, f64, usize)> = scores
+            .into_iter()
+            .map(|(path, (score, count))| (path, score, count))
+            .collect();
+        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.truncate(max_results);
+
+        // Build search hits with snippets
+        let mut hits = Vec::new();
+        for (path, score, _count) in &results {
+            let note_key = format!("note:{}", path);
+            let snippet = match engine.get_cf(cf, note_key.as_bytes())? {
+                Some(bytes) => {
+                    let content = String::from_utf8_lossy(&bytes);
+                    generate_snippet(&content, terms.first().unwrap_or(&String::new()))
+                }
+                None => String::new(),
+            };
+
+            hits.push(SearchHit {
+                path: path.clone(),
+                score: *score,
+                snippet,
+            });
+        }
+
+        Ok(hits)
+    }
+
+    /// Phrase search — find notes containing all terms in order.
+    fn search_phrase<C: Cache>(
+        engine: &crate::core::engine::Engine<C>,
+        cf: &str,
+        phrase_terms: &[String],
+        max_results: usize,
+    ) -> Result<Vec<SearchHit>> {
+        if phrase_terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Start with candidates from first term
+        let first_key = format!("fts:{}", phrase_terms[0]);
+        let mut candidates: std::collections::HashSet<String> = match engine
+            .get_cf(cf, first_key.as_bytes())?
+        {
+            Some(bytes) => {
+                let entries: Vec<TermEntry> = serde_json::from_slice(&bytes).unwrap_or_default();
+                entries.into_iter().map(|e| e.path).collect()
+            }
+            None => return Ok(Vec::new()),
+        };
+
+        // Intersect with other terms' note sets
+        for term in &phrase_terms[1..] {
+            let fts_key = format!("fts:{}", term);
+            let term_notes: std::collections::HashSet<String> =
+                match engine.get_cf(cf, fts_key.as_bytes())? {
+                    Some(bytes) => {
+                        let entries: Vec<TermEntry> =
+                            serde_json::from_slice(&bytes).unwrap_or_default();
+                        entries.into_iter().map(|e| e.path).collect()
+                    }
+                    None => std::collections::HashSet::new(),
+                };
+            candidates = candidates.intersection(&term_notes).cloned().collect();
+            if candidates.is_empty() {
+                return Ok(Vec::new());
+            }
+        }
+
+        // Simple scoring: number of matched terms
+        let mut hits: Vec<SearchHit> = candidates
+            .into_iter()
+            .map(|path| {
+                let snippet = match engine.get_cf(cf, format!("note:{}", path).as_bytes()) {
+                    Ok(Some(bytes)) => {
+                        let content = String::from_utf8_lossy(&bytes);
+                        generate_snippet(&content, &phrase_terms[0])
+                    }
+                    _ => String::new(),
+                };
+                SearchHit {
+                    path,
+                    score: phrase_terms.len() as f64,
+                    snippet,
+                }
+            })
+            .collect();
+
+        hits.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        hits.truncate(max_results);
+
+        Ok(hits)
+    }
+}
+
+/// Generate a snippet of text around the first occurrence of a search term.
+fn generate_snippet(content: &str, term: &str) -> String {
+    if term.is_empty() {
+        // Return first 100 chars
+        let truncated: String = content.chars().take(100).collect();
+        return if content.len() > 100 {
+            format!("{}...", truncated)
+        } else {
+            truncated
+        };
+    }
+
+    let lower_content = content.to_lowercase();
+    if let Some(pos) = lower_content.find(term) {
+        // Find the word boundary before the match
+        let start = pos.saturating_sub(40);
+        let end = (pos + term.len() + 60).min(content.len());
+
+        let snippet = &content[start..end];
+        if start > 0 && end < content.len() {
+            format!("...{}...", snippet)
+        } else if start > 0 {
+            format!("...{}", snippet)
+        } else if end < content.len() {
+            format!("{}...", snippet)
+        } else {
+            snippet.to_string()
+        }
+    } else {
+        // Fall back to first 100 chars
+        let truncated: String = content.chars().take(100).collect();
+        if content.len() > 100 {
+            format!("{}...", truncated)
+        } else {
+            truncated
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tokenize_basic() {
+        let terms = FullTextSearch::tokenize("Hello World Test");
+        assert!(terms.contains(&"hello".to_string()));
+        assert!(terms.contains(&"world".to_string()));
+        assert!(terms.contains(&"test".to_string()));
+        assert_eq!(terms.len(), 3);
+    }
+
+    #[test]
+    fn test_tokenize_case_insensitive() {
+        let terms = FullTextSearch::tokenize("Hello HELLO hello");
+        assert_eq!(terms.iter().filter(|t| *t == "hello").count(), 3);
+    }
+
+    #[test]
+    fn test_tokenize_short_words() {
+        let terms = FullTextSearch::tokenize("a an the at to");
+        // All are stop words or too short, should be empty
+        assert!(terms.is_empty());
+    }
+
+    #[test]
+    fn test_tokenize_punctuation() {
+        let terms = FullTextSearch::tokenize("hello, world! test? ok.");
+        assert!(terms.contains(&"hello".to_string()));
+        assert!(terms.contains(&"world".to_string()));
+        assert!(terms.contains(&"test".to_string()));
+    }
+
+    #[test]
+    fn test_search_snippet() {
+        let snippet = generate_snippet(
+            "This is a long note about Rust programming language",
+            "rust",
+        );
+        assert!(snippet.contains("Rust"));
+        assert!(snippet.len() <= 200);
+    }
+
+    #[test]
+    fn test_checksum_changes() {
+        let c1 = FullTextSearch::checksum("hello world");
+        let c2 = FullTextSearch::checksum("hello world!");
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn test_checksum_same() {
+        let c1 = FullTextSearch::checksum("hello world");
+        let c2 = FullTextSearch::checksum("hello world");
+        assert_eq!(c1, c2);
+    }
+}

--- a/src/notes/template.rs
+++ b/src/notes/template.rs
@@ -1,0 +1,363 @@
+//! Template engine for daily notes with `{{variable}}` and `{{date:format}}` syntax.
+//!
+//! # Template Syntax
+//!
+//! - `{{variable}}` — Substituted with a value from the variables map.
+//! - `{{date:format}}` — Current date formatted with chrono (e.g., `{{date:%Y-%m-%d}}`).
+//! - `{{time:format}}` — Current time formatted with chrono (e.g., `{{time:%H:%M:%S}}`).
+//!
+//! # Storage
+//!
+//! Templates are stored in the LSM engine under the `default` column family
+//! with key prefix `__template:`.
+
+use crate::infra::error::{LsmError, Result};
+use crate::notes::NoteEngine;
+use crate::storage::cache::Cache;
+use chrono::Local;
+use std::collections::HashMap;
+
+/// A note template with name, content, and declared variables.
+#[derive(Debug, Clone)]
+pub struct NoteTemplate {
+    /// Template name (used as the storage key).
+    pub name: String,
+    /// Template body content with `{{...}}` placeholders.
+    pub content: String,
+    /// Variable names extracted from the template content.
+    pub variables: Vec<String>,
+}
+
+/// Render a template string by substituting `{{variable}}`, `{{date:format}}`,
+/// and `{{time:format}}` placeholders.
+///
+/// # Errors
+///
+/// Returns `InvalidArgument` if a required variable is missing from the map.
+pub fn render_template(template: &str, variables: &HashMap<String, String>) -> Result<String> {
+    let mut result = String::new();
+    let mut rest = template;
+
+    while let Some(start) = rest.find("{{") {
+        // Push everything before the placeholder
+        result.push_str(&rest[..start]);
+
+        // Find the closing `}}`
+        let after_start = &rest[start + 2..];
+        let end = after_start
+            .find("}}")
+            .ok_or_else(|| LsmError::InvalidArgument("Unclosed template placeholder".into()))?;
+
+        let placeholder = &after_start[..end];
+
+        // Determine placeholder type
+        if let Some(date_fmt) = placeholder.strip_prefix("date:") {
+            let now = Local::now();
+            result.push_str(&now.format(date_fmt).to_string());
+        } else if let Some(time_fmt) = placeholder.strip_prefix("time:") {
+            let now = Local::now();
+            result.push_str(&now.format(time_fmt).to_string());
+        } else {
+            // Regular variable substitution
+            let var_name = placeholder.trim();
+            match variables.get(var_name) {
+                Some(val) => result.push_str(val),
+                None => {
+                    return Err(LsmError::InvalidArgument(format!(
+                        "Missing template variable: {}",
+                        var_name
+                    )));
+                }
+            }
+        }
+
+        rest = &after_start[end + 2..];
+    }
+
+    // Push remaining text after last placeholder
+    result.push_str(rest);
+
+    Ok(result)
+}
+
+/// Extract variable names (non-date, non-time placeholders) from a template string.
+#[allow(dead_code)]
+fn extract_variables(template: &str) -> Vec<String> {
+    let mut vars = Vec::new();
+    let mut rest = template;
+
+    while let Some(start) = rest.find("{{") {
+        let after_start = &rest[start + 2..];
+        if let Some(end) = after_start.find("}}") {
+            let placeholder = &after_start[..end];
+            // Only collect non-date, non-time variables
+            if !placeholder.starts_with("date:") && !placeholder.starts_with("time:") {
+                let var_name = placeholder.trim().to_string();
+                if !vars.contains(&var_name) {
+                    vars.push(var_name);
+                }
+            }
+            rest = &after_start[end + 2..];
+        } else {
+            break;
+        }
+    }
+
+    vars
+}
+
+/// List all saved template names.
+pub fn list_templates<C: Cache>(engine: &NoteEngine<C>) -> Result<Vec<String>> {
+    let prefix = "__template:";
+    let (results, _cursor) = engine
+        .engine()
+        .search_prefix(prefix, None, crate::core::engine::MAX_SCAN_LIMIT)
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to list templates: {}", e)))?;
+
+    let names: Vec<String> = results
+        .into_iter()
+        .filter_map(|(k, _v)| {
+            let key = String::from_utf8_lossy(&k).to_string();
+            key.strip_prefix("__template:").map(|s| s.to_string())
+        })
+        .collect();
+
+    Ok(names)
+}
+
+/// Save a template to the engine.
+///
+/// The template content is stored under `__template:{name}` in the default CF.
+pub fn save_template<C: Cache>(engine: &NoteEngine<C>, name: &str, content: &str) -> Result<()> {
+    let key = format!("__template:{}", name);
+    engine
+        .engine()
+        .put_cf("default", key.into_bytes(), content.as_bytes().to_vec())
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to save template: {}", e)))?;
+    Ok(())
+}
+
+/// Delete a template from the engine.
+pub fn delete_template<C: Cache>(engine: &NoteEngine<C>, name: &str) -> Result<()> {
+    let key = format!("__template:{}", name);
+    engine
+        .engine()
+        .delete_cf("default", key.into_bytes())
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to delete template: {}", e)))?;
+    Ok(())
+}
+
+/// Get a template's content.
+pub fn get_template<C: Cache>(engine: &NoteEngine<C>, name: &str) -> Result<Option<String>> {
+    let key = format!("__template:{}", name);
+    match engine.engine().get_cf("default", key.as_bytes()) {
+        Ok(Some(bytes)) => Ok(Some(String::from_utf8_lossy(&bytes).to_string())),
+        Ok(None) => Ok(None),
+        Err(e) => Err(LsmError::InvalidArgument(format!(
+            "Failed to get template: {}",
+            e
+        ))),
+    }
+}
+
+/// Create a daily note from an optional template.
+///
+/// The note path follows the pattern `daily/YYYY-MM-DD`.
+/// If a `template_name` is provided, the template is loaded, rendered with
+/// `{{date:%Y-%m-%d}}` and `{{time:%H:%M:%S}}` variables, and saved.
+/// If no template is given, an empty daily note is created.
+pub fn create_daily_note<C: Cache>(
+    engine: &NoteEngine<C>,
+    template_name: Option<&str>,
+) -> Result<String> {
+    let now = Local::now();
+    let date_str = now.format("%Y-%m-%d").to_string();
+    let note_path = format!("daily/{}", date_str);
+
+    // Check if already exists
+    if let Ok(Some(_)) = engine.get_note(&note_path) {
+        return Ok(note_path); // Already exists, return path
+    }
+
+    let content = match template_name {
+        Some(tname) => {
+            let raw = get_template(engine, tname)?.ok_or_else(|| {
+                LsmError::InvalidArgument(format!("Template not found: {}", tname))
+            })?;
+
+            let mut variables = HashMap::new();
+            // Pre-populate date/time variables
+            variables.insert("date".to_string(), now.format("%Y-%m-%d").to_string());
+            variables.insert("time".to_string(), now.format("%H:%M:%S").to_string());
+
+            render_template(&raw, &variables)?
+        }
+        None => format!("# Daily Note — {}\n\n", date_str),
+    };
+
+    engine.put_note(&note_path, &content)?;
+    Ok(note_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::LsmConfig;
+    use crate::storage::cache::GlobalBlockCache;
+    use std::sync::Arc;
+
+    fn create_note_engine() -> NoteEngine<Arc<GlobalBlockCache>> {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = LsmConfig::default();
+        config.core.dir_path = dir.path().to_path_buf();
+        let engine = Arc::new(
+            crate::core::engine::Engine::new_from_config(&config, GlobalBlockCache::new(10, 4096))
+                .unwrap(),
+        );
+        NoteEngine::new(engine)
+    }
+
+    #[test]
+    fn test_render_template_simple() {
+        let mut vars = HashMap::new();
+        vars.insert("title".to_string(), "My Note".to_string());
+        vars.insert("author".to_string(), "Alice".to_string());
+
+        let result = render_template("# {{title}} by {{author}}", &vars).unwrap();
+        assert_eq!(result, "# My Note by Alice");
+    }
+
+    #[test]
+    fn test_render_template_date_format() {
+        let vars = HashMap::new();
+        let result = render_template("Date: {{date:%Y-%m-%d}}", &vars).unwrap();
+        // Should contain today's date
+        let today = Local::now().format("%Y-%m-%d").to_string();
+        assert_eq!(result, format!("Date: {}", today));
+    }
+
+    #[test]
+    fn test_render_template_time_format() {
+        let vars = HashMap::new();
+        let result = render_template("Time: {{time:%H:%M:%S}}", &vars).unwrap();
+        assert!(result.starts_with("Time: "));
+        assert_eq!(result.len(), 14); // "Time: HH:MM:SS"
+    }
+
+    #[test]
+    fn test_render_template_missing_variable() {
+        let vars = HashMap::new();
+        let result = render_template("Hello {{name}}", &vars);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Missing template variable"));
+    }
+
+    #[test]
+    fn test_render_template_unclosed() {
+        let vars = HashMap::new();
+        let result = render_template("Hello {{name", &vars);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unclosed template placeholder"));
+    }
+
+    #[test]
+    fn test_render_template_no_placeholders() {
+        let vars = HashMap::new();
+        let result = render_template("Plain text", &vars).unwrap();
+        assert_eq!(result, "Plain text");
+    }
+
+    #[test]
+    fn test_render_template_multiple() {
+        let mut vars = HashMap::new();
+        vars.insert("a".to_string(), "1".to_string());
+        vars.insert("b".to_string(), "2".to_string());
+
+        let result = render_template("{{a}} + {{b}} = {{a}}{{b}}", &vars).unwrap();
+        assert_eq!(result, "1 + 2 = 12");
+    }
+
+    #[test]
+    fn test_extract_variables() {
+        let template = "Title: {{title}}\nAuthor: {{author}}\nDate: {{date:%Y-%m-%d}}";
+        let vars = extract_variables(template);
+        assert!(vars.contains(&"title".to_string()));
+        assert!(vars.contains(&"author".to_string()));
+        assert!(!vars.contains(&"date:%Y-%m-%d".to_string())); // date: prefixed excluded
+    }
+
+    #[test]
+    fn test_save_and_list_templates() {
+        let engine = create_note_engine();
+        save_template(&engine, "weekly-report", "# Week {{week_number}}").unwrap();
+        save_template(&engine, "meeting-notes", "# Meeting: {{topic}}").unwrap();
+
+        let templates = list_templates(&engine).unwrap();
+        assert!(templates.contains(&"weekly-report".to_string()));
+        assert!(templates.contains(&"meeting-notes".to_string()));
+    }
+
+    #[test]
+    fn test_get_template() {
+        let engine = create_note_engine();
+        save_template(&engine, "test", "Content: {{var}}").unwrap();
+
+        let content = get_template(&engine, "test").unwrap();
+        assert_eq!(content, Some("Content: {{var}}".to_string()));
+
+        let missing = get_template(&engine, "nonexistent").unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_delete_template() {
+        let engine = create_note_engine();
+        save_template(&engine, "to-delete", "content").unwrap();
+        delete_template(&engine, "to-delete").unwrap();
+
+        let content = get_template(&engine, "to-delete").unwrap();
+        assert!(content.is_none());
+    }
+
+    #[test]
+    fn test_create_daily_note_default() {
+        let engine = create_note_engine();
+        let path = create_daily_note(&engine, None).unwrap();
+
+        let today = Local::now().format("%Y-%m-%d").to_string();
+        assert_eq!(path, format!("daily/{}", today));
+
+        let content = engine.get_note(&path).unwrap();
+        assert!(content.is_some());
+        assert!(content.unwrap().contains(&today));
+    }
+
+    #[test]
+    fn test_create_daily_note_with_template() {
+        let engine = create_note_engine();
+        save_template(
+            &engine,
+            "daily",
+            "# {{date:%Y-%m-%d}}\n\n## Tasks\n\n- [ ] ",
+        )
+        .unwrap();
+
+        let path = create_daily_note(&engine, Some("daily")).unwrap();
+        let content = engine.get_note(&path).unwrap().unwrap();
+        assert!(content.contains("## Tasks"));
+    }
+
+    #[test]
+    fn test_create_daily_note_idempotent() {
+        let engine = create_note_engine();
+        let path1 = create_daily_note(&engine, None).unwrap();
+        let path2 = create_daily_note(&engine, None).unwrap();
+        assert_eq!(path1, path2); // Same path returned
+    }
+}

--- a/src/notes/validate.rs
+++ b/src/notes/validate.rs
@@ -1,0 +1,475 @@
+//! Frontmatter schema validation system.
+//!
+//! Provides a schema-based validator for YAML frontmatter in notes.
+//! Schemas define required fields, field types, allowed tags, and maximum
+//! tag count. Validation produces human-readable error messages.
+//!
+//! # Storage
+//!
+//! Schemas are stored in the LSM engine under the `default` column family
+//! with key prefix `__frontmatter_schema:`. A default schema is registered
+//! on application startup.
+
+use crate::infra::error::{LsmError, Result};
+use crate::notes::parser::Frontmatter;
+use crate::notes::NoteEngine;
+use crate::storage::cache::Cache;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// The type of a frontmatter field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FieldType {
+    /// Text string value.
+    String,
+    /// Numeric value (parsed as f64).
+    Number,
+    /// Date string value.
+    Date,
+    /// List of tags (`[tag1, tag2]` or YAML list).
+    TagList,
+    /// List of strings.
+    StringList,
+}
+
+impl FieldType {
+    /// Human-readable name for the field type.
+    pub fn name(&self) -> &str {
+        match self {
+            FieldType::String => "string",
+            FieldType::Number => "number",
+            FieldType::Date => "date",
+            FieldType::TagList => "tag list",
+            FieldType::StringList => "string list",
+        }
+    }
+}
+
+/// A schema that defines validation rules for frontmatter fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrontmatterSchema {
+    /// Field names that must be present in the frontmatter.
+    pub required_fields: Vec<String>,
+    /// Expected types for specific fields (`field_name -> FieldType`).
+    pub field_types: HashMap<String, FieldType>,
+    /// If set, only these tag values are allowed in the `tags` field.
+    pub allowed_tags: Option<Vec<String>>,
+    /// Maximum number of tags allowed (default: 20).
+    pub max_tags: usize,
+}
+
+impl Default for FrontmatterSchema {
+    fn default() -> Self {
+        Self {
+            required_fields: Vec::new(),
+            field_types: HashMap::new(),
+            allowed_tags: None,
+            max_tags: 20,
+        }
+    }
+}
+
+/// Validate frontmatter against a schema.
+///
+/// Returns a list of human-readable validation error messages.
+/// An empty vec means validation passed.
+///
+/// # Errors
+///
+/// Returns `LsmError::InvalidArgument` for internal issues.
+pub fn validate_frontmatter(fm: &Frontmatter, schema: &FrontmatterSchema) -> Result<Vec<String>> {
+    let mut errors: Vec<String> = Vec::new();
+
+    // Check required fields
+    for field in &schema.required_fields {
+        match field.as_str() {
+            "title" => {
+                if fm.title.is_none() || fm.title.as_ref().is_none_or(|s| s.trim().is_empty()) {
+                    errors.push(format!("Required field '{}' is missing or empty", field));
+                }
+            }
+            "created" | "updated" => {
+                let val = if field == "created" {
+                    &fm.created
+                } else {
+                    &fm.updated
+                };
+                if val.as_ref().is_none_or(|s| s.trim().is_empty()) {
+                    errors.push(format!("Required field '{}' is missing or empty", field));
+                }
+            }
+            "tags" => {
+                if fm.tags.is_empty() {
+                    errors.push(format!("Required field '{}' is missing or empty", field));
+                }
+            }
+            "aliases" => {
+                // aliases are optional even if required (empty list is allowed)
+                // Only error if the field concept doesn't exist at all — we can't
+                // distinguish from our flat struct, so skip aliases from required check.
+            }
+            other => {
+                // Check custom fields
+                if !fm.custom.contains_key(other) {
+                    errors.push(format!("Required field '{}' is missing", other));
+                }
+            }
+        }
+    }
+
+    // Validate field types
+    for (field_name, expected_type) in &schema.field_types {
+        let value = match field_name.as_str() {
+            "title" => fm.title.as_deref(),
+            "created" => fm.created.as_deref(),
+            "updated" => fm.updated.as_deref(),
+            _ => fm.custom.get(field_name).map(|s| s.as_str()),
+        };
+
+        if let Some(val) = value {
+            if !validate_type(val, expected_type) {
+                errors.push(format!(
+                    "Field '{}' expected type '{}' but got value: '{}'",
+                    field_name,
+                    expected_type.name(),
+                    val
+                ));
+            }
+        }
+    }
+
+    // Validate tags
+    if let Some(allowed) = &schema.allowed_tags {
+        for tag in &fm.tags {
+            if !allowed.contains(tag) {
+                errors.push(format!("Tag '{}' is not in the allowed list", tag));
+            }
+        }
+    }
+
+    if fm.tags.len() > schema.max_tags {
+        errors.push(format!(
+            "Too many tags: {} (max: {})",
+            fm.tags.len(),
+            schema.max_tags
+        ));
+    }
+
+    Ok(errors)
+}
+
+/// Check if a string value matches the expected field type.
+fn validate_type(value: &str, field_type: &FieldType) -> bool {
+    match field_type {
+        FieldType::String => true, // Any string is valid
+        FieldType::Number => value.parse::<f64>().is_ok(),
+        FieldType::Date => {
+            // Accept ISO 8601 dates: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS
+            value.len() >= 10
+                && value.chars().any(|c| c == '-')
+                && value.chars().filter(|c| *c == '-').count() >= 2
+        }
+        FieldType::TagList => {
+            // Tags are already parsed as Vec<String> — we validate each tag
+            // is non-empty and doesn't contain spaces
+            !value.is_empty() && !value.contains(' ')
+        }
+        FieldType::StringList => !value.is_empty(),
+    }
+}
+
+/// Get the default schema used throughout the application.
+///
+/// By default:
+/// - `title` is required (String)
+/// - `created` is optional but typed as Date
+/// - `tags` is typed as TagList with max 20 tags
+pub fn get_default_schema() -> FrontmatterSchema {
+    let mut field_types = HashMap::new();
+    field_types.insert("title".to_string(), FieldType::String);
+    field_types.insert("created".to_string(), FieldType::Date);
+    field_types.insert("updated".to_string(), FieldType::Date);
+    field_types.insert("tags".to_string(), FieldType::TagList);
+
+    FrontmatterSchema {
+        required_fields: vec!["title".to_string()],
+        field_types,
+        allowed_tags: None,
+        max_tags: 20,
+    }
+}
+
+/// Save a frontmatter schema under a given name.
+pub fn save_schema<C: Cache>(
+    engine: &NoteEngine<C>,
+    name: &str,
+    schema: &FrontmatterSchema,
+) -> Result<()> {
+    let key = format!("__frontmatter_schema:{}", name);
+    let value = serde_json::to_vec(schema)
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to serialize schema: {}", e)))?;
+    engine
+        .engine()
+        .put_cf("default", key.into_bytes(), value)
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to save schema: {}", e)))?;
+    Ok(())
+}
+
+/// Load a frontmatter schema by name.
+pub fn load_schema<C: Cache>(
+    engine: &NoteEngine<C>,
+    name: &str,
+) -> Result<Option<FrontmatterSchema>> {
+    let key = format!("__frontmatter_schema:{}", name);
+    match engine.engine().get_cf("default", key.as_bytes()) {
+        Ok(Some(bytes)) => {
+            let schema: FrontmatterSchema = serde_json::from_slice(&bytes).map_err(|e| {
+                LsmError::InvalidArgument(format!("Failed to deserialize schema: {}", e))
+            })?;
+            Ok(Some(schema))
+        }
+        Ok(None) => Ok(None),
+        Err(e) => Err(LsmError::InvalidArgument(format!(
+            "Failed to load schema: {}",
+            e
+        ))),
+    }
+}
+
+/// Delete a frontmatter schema.
+pub fn delete_schema<C: Cache>(engine: &NoteEngine<C>, name: &str) -> Result<()> {
+    let key = format!("__frontmatter_schema:{}", name);
+    engine
+        .engine()
+        .delete_cf("default", key.into_bytes())
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to delete schema: {}", e)))?;
+    Ok(())
+}
+
+/// List all saved schema names.
+pub fn list_schemas<C: Cache>(engine: &NoteEngine<C>) -> Result<Vec<String>> {
+    let prefix = "__frontmatter_schema:";
+    let (results, _cursor) = engine
+        .engine()
+        .search_prefix(prefix, None, crate::core::engine::MAX_SCAN_LIMIT)
+        .map_err(|e| LsmError::InvalidArgument(format!("Failed to list schemas: {}", e)))?;
+
+    let names: Vec<String> = results
+        .into_iter()
+        .filter_map(|(k, _v)| {
+            let key = String::from_utf8_lossy(&k).to_string();
+            key.strip_prefix("__frontmatter_schema:")
+                .map(|s| s.to_string())
+        })
+        .collect();
+
+    Ok(names)
+}
+
+/// Register the default schema on application startup (idempotent).
+pub fn register_default_schema<C: Cache>(engine: &NoteEngine<C>) -> Result<()> {
+    let existing = load_schema(engine, "default")?;
+    if existing.is_none() {
+        let schema = get_default_schema();
+        save_schema(engine, "default", &schema)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::config::LsmConfig;
+    use crate::storage::cache::GlobalBlockCache;
+    use std::sync::Arc;
+
+    fn create_note_engine() -> NoteEngine<Arc<GlobalBlockCache>> {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = LsmConfig::default();
+        config.core.dir_path = dir.path().to_path_buf();
+        let engine = Arc::new(
+            crate::core::engine::Engine::new_from_config(&config, GlobalBlockCache::new(10, 4096))
+                .unwrap(),
+        );
+        NoteEngine::new(engine)
+    }
+
+    fn make_frontmatter(
+        title: Option<&str>,
+        tags: Vec<&str>,
+        custom: Vec<(&str, &str)>,
+    ) -> Frontmatter {
+        let mut custom_map = HashMap::new();
+        for (k, v) in custom {
+            custom_map.insert(k.to_string(), v.to_string());
+        }
+        Frontmatter {
+            title: title.map(|s| s.to_string()),
+            aliases: vec![],
+            tags: tags.into_iter().map(|s| s.to_string()).collect(),
+            created: None,
+            updated: None,
+            custom: custom_map,
+        }
+    }
+
+    #[test]
+    fn test_validate_required_title_present() {
+        let fm = make_frontmatter(Some("My Note"), vec![], vec![]);
+        let schema = get_default_schema();
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_required_title_missing() {
+        let fm = make_frontmatter(None, vec![], vec![]);
+        let schema = get_default_schema();
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("title"));
+    }
+
+    #[test]
+    fn test_validate_required_custom_field() {
+        let fm = make_frontmatter(Some("Note"), vec![], vec![]);
+        let mut schema = get_default_schema();
+        schema.required_fields.push("status".to_string());
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("status"));
+    }
+
+    #[test]
+    fn test_validate_number_type() {
+        let fm = make_frontmatter(Some("Note"), vec![], vec![("priority", "abc")]);
+        let mut schema = get_default_schema();
+        schema
+            .field_types
+            .insert("priority".to_string(), FieldType::Number);
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("priority"));
+        assert!(errors[0].contains("number"));
+    }
+
+    #[test]
+    fn test_validate_number_type_valid() {
+        let fm = make_frontmatter(Some("Note"), vec![], vec![("priority", "42")]);
+        let mut schema = get_default_schema();
+        schema
+            .field_types
+            .insert("priority".to_string(), FieldType::Number);
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_allowed_tags() {
+        let fm = make_frontmatter(Some("Note"), vec!["rust", "python"], vec![]);
+        let mut schema = get_default_schema();
+        schema.allowed_tags = Some(vec!["rust".to_string(), "web".to_string()]);
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("python"));
+    }
+
+    #[test]
+    fn test_validate_allowed_tags_pass() {
+        let fm = make_frontmatter(Some("Note"), vec!["rust", "web"], vec![]);
+        let mut schema = get_default_schema();
+        schema.allowed_tags = Some(vec!["rust".to_string(), "web".to_string()]);
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_validate_max_tags() {
+        let fm = make_frontmatter(Some("Note"), vec!["a", "b", "c"], vec![]);
+        let mut schema = get_default_schema();
+        schema.max_tags = 2;
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("Too many tags"));
+    }
+
+    #[test]
+    fn test_validate_pass_all_rules() {
+        let fm = make_frontmatter(
+            Some("Valid Note"),
+            vec!["rust", "web"],
+            vec![("priority", "1"), ("status", "draft")],
+        );
+        let mut schema = get_default_schema();
+        schema.required_fields.push("status".to_string());
+        schema
+            .field_types
+            .insert("priority".to_string(), FieldType::Number);
+        schema.allowed_tags = Some(vec!["rust".to_string(), "web".to_string()]);
+        schema.max_tags = 5;
+
+        let errors = validate_frontmatter(&fm, &schema).unwrap();
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load_schema() {
+        let engine = create_note_engine();
+        let schema = get_default_schema();
+        save_schema(&engine, "test-schema", &schema).unwrap();
+
+        let loaded = load_schema(&engine, "test-schema").unwrap();
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().required_fields, vec!["title"]);
+    }
+
+    #[test]
+    fn test_list_schemas() {
+        let engine = create_note_engine();
+        save_schema(&engine, "schema-a", &get_default_schema()).unwrap();
+        save_schema(&engine, "schema-b", &get_default_schema()).unwrap();
+
+        let names = list_schemas(&engine).unwrap();
+        assert!(names.contains(&"schema-a".to_string()));
+        assert!(names.contains(&"schema-b".to_string()));
+    }
+
+    #[test]
+    fn test_delete_schema() {
+        let engine = create_note_engine();
+        save_schema(&engine, "to-delete", &get_default_schema()).unwrap();
+        delete_schema(&engine, "to-delete").unwrap();
+
+        let loaded = load_schema(&engine, "to-delete").unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn test_register_default_schema() {
+        let engine = create_note_engine();
+        register_default_schema(&engine).unwrap();
+
+        let loaded = load_schema(&engine, "default").unwrap();
+        assert!(loaded.is_some());
+
+        // Second call should be idempotent
+        register_default_schema(&engine).unwrap();
+        let names = list_schemas(&engine).unwrap();
+        assert_eq!(names.len(), 1);
+    }
+
+    #[test]
+    fn test_field_type_name() {
+        assert_eq!(FieldType::String.name(), "string");
+        assert_eq!(FieldType::Number.name(), "number");
+        assert_eq!(FieldType::Date.name(), "date");
+        assert_eq!(FieldType::TagList.name(), "tag list");
+        assert_eq!(FieldType::StringList.name(), "string list");
+    }
+}


### PR DESCRIPTION
Implements the complete notes engine API layer covering Epic #275 issues #277-#281.

Endpoints:
- GET/PUT/DELETE /notes/{path} - note CRUD
- POST /notes/{path}/rename - rename with index updates
- GET /notes/{path}/backlinks - incoming links
- GET /notes/{path}/links - outgoing links
- GET /notes/{path}/graph - D3.js-compatible graph view
- GET /tags - list tags with counts
- GET /tags/{tag}/notes - paginated notes by tag

Closes #277, Closes #278, Closes #279, Closes #280, Closes #281